### PR TITLE
Add service READMEs to document architecture

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,43 @@
+# VidFriends Backend
+
+The VidFriends backend is a Go service that exposes RESTful APIs for authentication,
+friend management, and sharing video links enriched with metadata lookups. The
+service talks to PostgreSQL via the `pgx` driver and runs database migrations on
+startup.
+
+## Project layout
+
+- `cmd/vidfriends/` – entrypoint for running the HTTP server and database migrations.
+- `internal/` – packages that contain handlers, data access, and domain logic.
+- `migrations/` – SQL migrations applied at startup or via the CLI tooling.
+
+## Running the service
+
+1. Ensure PostgreSQL is running and the connection details in `backend/.env` (copy
+   from `.env.example`) are correct.
+2. Apply database migrations:
+   ```bash
+   go run ./cmd/vidfriends migrate up
+   ```
+3. Start the API server:
+   ```bash
+   go run ./cmd/vidfriends serve
+   ```
+   The server listens on `http://localhost:8080` by default.
+
+## Testing
+
+Run the Go test suite:
+
+```bash
+go test ./...
+```
+
+Use `go test -race ./...` when you need additional data race checks.
+
+## Tooling
+
+- [`air`](https://github.com/cosmtrek/air) or [`reflex`](https://github.com/cespare/reflex)
+  can be used for live-reload during development.
+- [`golangci-lint`](https://golangci-lint.run/) is recommended to ensure the codebase
+  conforms to linting rules before committing changes.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,47 @@
+# VidFriends Frontend
+
+The VidFriends frontend is a React + TypeScript single-page application that lets
+users authenticate, manage friend relationships, and share video links.
+
+## Project layout
+
+- `src/` – application components, hooks, and utility modules.
+- `public/` – static assets served with the application shell.
+- `tests/` – component and integration tests.
+
+## Prerequisites
+
+Install Node.js 18+ and either `pnpm` (preferred) or `npm`.
+
+## Running the development server
+
+1. Copy environment variables:
+   ```bash
+   cp .env.example .env
+   ```
+2. Install dependencies:
+   ```bash
+   pnpm install
+   ```
+3. Start the dev server:
+   ```bash
+   pnpm dev
+   ```
+   The app is served at `http://localhost:5173` by default.
+
+## Building for production
+
+```bash
+pnpm build
+```
+
+The output is placed in the `dist/` directory and can be served by any static host.
+
+## Testing
+
+```bash
+pnpm test
+```
+
+For end-to-end testing, use Playwright or Cypress according to the team's
+preference.


### PR DESCRIPTION
## Summary
- add a backend README with instructions for running and testing the Go service
- add a frontend README describing the development workflow for the SPA

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4b38fd3fc832fa37f9d58016739b7