### PR TITLE
Add environment templates for VidFriends setup

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,13 @@
+# Backend service configuration for VidFriends
+
+# HTTP server port the API listens on.
+PORT=8080
+
+# PostgreSQL connection string used for development.
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/vidfriends?sslmode=disable
+
+# Secret used to sign session cookies. Replace with a securely generated value.
+SESSION_SECRET=replace-with-secure-random-string
+
+# Optional path override for the yt-dlp binary if it is not on the PATH.
+YT_DLP_PATH=yt-dlp

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,19 @@
+# Shared environment configuration for Docker Compose deployments.
+
+# Database credentials used by PostgreSQL and the backend service.
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=vidfriends
+
+# Connection string the backend uses to reach PostgreSQL inside Compose.
+DATABASE_URL=postgres://postgres:postgres@db:5432/vidfriends?sslmode=disable
+
+# Secret for signing backend session cookies. Replace before running in production.
+SESSION_SECRET=replace-with-secure-random-string
+
+# Optional path to the yt-dlp binary inside the backend container.
+YT_DLP_PATH=/usr/local/bin/yt-dlp
+
+# Hostnames/ports exposed by the services.
+BACKEND_PORT=8080
+FRONTEND_PORT=5173

--- a/docs/STARTUP.md
+++ b/docs/STARTUP.md
@@ -66,10 +66,19 @@ cp deploy/.env.example deploy/.env
 
 Update the copied files with values that match your environment. At a minimum you need to provide:
 
-- `DATABASE_URL` – PostgreSQL connection string used by the Go service.
-- `SESSION_SECRET` – random 32+ byte string for signing session cookies.
+- `DATABASE_URL` – PostgreSQL connection string used by the Go service (defaults to
+  `postgres://postgres:postgres@localhost:5432/vidfriends?sslmode=disable`).
+- `SESSION_SECRET` – random 32+ byte string for signing session cookies. Generate
+  a new value with `openssl rand -base64 32`.
 - `YT_DLP_PATH` – optional path to the `yt-dlp` binary if it is not on `$PATH`.
-- `VITE_API_BASE_URL` – API origin for the frontend (`http://localhost:8080` in local dev).
+- `VITE_API_BASE_URL` – API origin for the frontend (`http://localhost:8080` in
+  local development).
+- `VITE_USE_MOCKS` – toggle the frontend's mock service layer (`false` by
+  default).
+- `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` – credentials the
+  Docker Compose workflow applies to the PostgreSQL container.
+- `BACKEND_PORT` / `FRONTEND_PORT` – override ports exposed by Docker Compose if
+  `8080` or `5173` conflict with other services on your machine.
 
 > **Tip:** Generate secure secrets with `openssl rand -base64 32`.
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,7 @@
+# Frontend environment variables for VidFriends
+
+# Base URL for the backend API.
+VITE_API_BASE_URL=http://localhost:8080
+
+# Toggle mock service usage during development ("true" or "false").
+VITE_USE_MOCKS=false


### PR DESCRIPTION
## Summary
- add example environment variable files for the backend, frontend, and deploy workflows
- document the core configuration values referenced by the startup guide

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4b4591f58832f8f0afeaec85f8ccc