### PR TITLE
Add CI workflow for tests and linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,89 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  go-tests:
+    name: Go Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          fallback-go-version: '1.21'
+
+      - name: Run Go unit tests
+        working-directory: backend
+        run: |
+          if [ -f go.mod ]; then
+            go test ./...
+          else
+            echo "No Go module found in backend/. Skipping Go tests."
+          fi
+
+  frontend-tests:
+    name: Frontend Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: |
+            frontend/package-lock.json
+            frontend/pnpm-lock.yaml
+            frontend/yarn.lock
+
+      - name: Install dependencies and run tests
+        working-directory: frontend
+        run: |
+          if [ -f package.json ]; then
+            if [ -f pnpm-lock.yaml ]; then
+              corepack enable pnpm
+              pnpm install --frozen-lockfile
+              pnpm test -- --watch=false
+            elif [ -f package-lock.json ]; then
+              npm ci
+              npm test -- --watch=false
+            elif [ -f yarn.lock ]; then
+              corepack enable
+              yarn install --immutable
+              yarn test --watch=false
+            else
+              npm install
+              npm test -- --watch=false
+            fi
+          else
+            echo "No frontend/package.json found. Skipping frontend tests."
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - name: Run lint checks
+        run: bash scripts/lint.sh

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@ A living checklist of follow-up work and enhancements to guide ongoing developme
 
 ## Infrastructure & Tooling
 - [x] Review and document the Docker Compose services in `deploy/` to clarify how the backend, frontend, and database interact.
-- [ ] Automate CI workflows to run Go tests, frontend unit tests, and linting on every pull request.
+- [x] Automate CI workflows to run Go tests, frontend unit tests, and linting on every pull request.
 - [ ] Set up container build automation that publishes multi-architecture images (x86_64 and arm64).
 
 ## Backend

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXIT_CODE=0
+
+mapfile -t GO_FILES < <(find "$ROOT_DIR/backend" -type f -name '*.go' -print)
+if [[ ${#GO_FILES[@]} -gt 0 ]]; then
+  echo "== Running gofmt checks =="
+  mapfile -t UNFORMATTED < <(gofmt -l "${GO_FILES[@]}" || true)
+  if [[ ${#UNFORMATTED[@]} -gt 0 ]]; then
+    echo "The following Go files need formatting:"
+    printf '  %s\n' "${UNFORMATTED[@]}"
+    EXIT_CODE=1
+  else
+    echo "All Go files are properly formatted."
+  fi
+else
+  echo "No Go files found under backend/. Skipping gofmt check."
+fi
+
+if [[ -f "$ROOT_DIR/frontend/package.json" ]]; then
+  echo -e "\n== Running frontend lint =="
+  pushd "$ROOT_DIR/frontend" >/dev/null
+  if [[ -f pnpm-lock.yaml ]]; then
+    corepack enable pnpm
+    pnpm install --frozen-lockfile
+    pnpm run lint
+  elif [[ -f yarn.lock ]]; then
+    corepack enable
+    yarn install --immutable
+    yarn lint
+  else
+    if [[ -f package-lock.json ]]; then
+      npm ci
+    else
+      npm install
+    fi
+    npm run lint
+  fi
+  popd >/dev/null
+else
+  echo "No frontend/package.json found. Skipping frontend lint."
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs Go tests, frontend tests, and lint checks on pushes and pull requests
- provide a lint helper script that skips missing stacks gracefully and supports pnpm, yarn, and npm
- update the TODO checklist to mark CI automation as complete

## Testing
- bash scripts/lint.sh

------
https://chatgpt.com/codex/tasks/task_e_68d4c34abaa4832f896c5be5a36f7a58