### PR TITLE
Implement authentication endpoints with session refresh

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,7 @@ A living checklist of follow-up work and enhancements to guide ongoing developme
 
 ## Backend
 - [x] Flesh out the Go project structure under `backend/` with handlers, data models, and migrations.
-- [ ] Implement authentication endpoints, including session management and token refresh.
+- [x] Implement authentication endpoints, including session management and token refresh.
 - [ ] Add friend management APIs (invite, accept, block) with appropriate database migrations.
 - [ ] Integrate yt-dlp metadata lookups for shared video links and cache results.
 - [ ] Write comprehensive Go tests for handlers, repositories, and domain logic.

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require github.com/jackc/pgx/v5 v5.5.4
 
 require (
+	github.com/google/uuid v1.3.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
+github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/Y25WS6cokEszi5g+S0QxI/d45PkRi7Nk=

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -9,7 +9,9 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
+	"github.com/vidfriends/backend/internal/auth"
 	"github.com/vidfriends/backend/internal/config"
 	"github.com/vidfriends/backend/internal/db"
 	"github.com/vidfriends/backend/internal/handlers"
@@ -47,9 +49,10 @@ func serve(ctx context.Context) error {
 	defer pool.Close()
 
 	deps := handlers.Dependencies{
-		Users:   nil,
-		Friends: nil,
-		Videos:  nil,
+		Users:    nil,
+		Sessions: auth.NewManager(15*time.Minute, 24*time.Hour),
+		Friends:  nil,
+		Videos:   nil,
 	}
 
 	mux := http.NewServeMux()

--- a/backend/internal/auth/session_manager.go
+++ b/backend/internal/auth/session_manager.go
@@ -1,0 +1,118 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/vidfriends/backend/internal/models"
+)
+
+var (
+	// ErrSessionNotFound indicates the provided refresh token does not map to an active session.
+	ErrSessionNotFound = errors.New("session not found")
+	// ErrRefreshTokenExpired indicates the refresh token has expired and cannot be used.
+	ErrRefreshTokenExpired = errors.New("refresh token expired")
+)
+
+// Manager manages the lifecycle of issued session tokens in-memory.
+//
+// It is intended for development environments where a shared cache such as Redis is not yet available.
+// Callers should wrap it with appropriate persistence for production deployments.
+type Manager struct {
+	accessTTL  time.Duration
+	refreshTTL time.Duration
+
+	mu       sync.Mutex
+	sessions map[string]sessionRecord
+}
+
+type sessionRecord struct {
+	userID    string
+	expiresAt time.Time
+}
+
+// NewManager constructs a Manager that issues access and refresh tokens with the provided TTLs.
+func NewManager(accessTTL, refreshTTL time.Duration) *Manager {
+	return &Manager{
+		accessTTL:  accessTTL,
+		refreshTTL: refreshTTL,
+		sessions:   make(map[string]sessionRecord),
+	}
+}
+
+// Issue creates a new pair of access and refresh tokens for the provided user identifier.
+func (m *Manager) Issue(_ context.Context, userID string) (models.SessionTokens, error) {
+	if userID == "" {
+		return models.SessionTokens{}, errors.New("user id must be provided")
+	}
+
+	now := time.Now().UTC()
+	accessToken, err := randomToken()
+	if err != nil {
+		return models.SessionTokens{}, err
+	}
+
+	refreshToken, err := randomToken()
+	if err != nil {
+		return models.SessionTokens{}, err
+	}
+
+	tokens := models.SessionTokens{
+		AccessToken:      accessToken,
+		AccessExpiresAt:  now.Add(m.accessTTL),
+		RefreshToken:     refreshToken,
+		RefreshExpiresAt: now.Add(m.refreshTTL),
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sessions[refreshToken] = sessionRecord{userID: userID, expiresAt: tokens.RefreshExpiresAt}
+
+	return tokens, nil
+}
+
+// Refresh exchanges a refresh token for a new session token pair.
+func (m *Manager) Refresh(_ context.Context, refreshToken string) (models.SessionTokens, error) {
+	if refreshToken == "" {
+		return models.SessionTokens{}, ErrSessionNotFound
+	}
+
+	m.mu.Lock()
+	record, ok := m.sessions[refreshToken]
+	if !ok {
+		m.mu.Unlock()
+		return models.SessionTokens{}, ErrSessionNotFound
+	}
+	if time.Now().UTC().After(record.expiresAt) {
+		delete(m.sessions, refreshToken)
+		m.mu.Unlock()
+		return models.SessionTokens{}, ErrRefreshTokenExpired
+	}
+	delete(m.sessions, refreshToken)
+	m.mu.Unlock()
+
+	return m.Issue(context.Background(), record.userID)
+}
+
+// Revoke removes the provided refresh token from the active session store.
+func (m *Manager) Revoke(_ context.Context, refreshToken string) {
+	if refreshToken == "" {
+		return
+	}
+	m.mu.Lock()
+	delete(m.sessions, refreshToken)
+	m.mu.Unlock()
+}
+
+func randomToken() (string, error) {
+	const size = 32
+	buf := make([]byte, size)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}

--- a/backend/internal/handlers/auth.go
+++ b/backend/internal/handlers/auth.go
@@ -2,12 +2,25 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
+	"net/mail"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/vidfriends/backend/internal/auth"
+	"github.com/vidfriends/backend/internal/models"
+	"github.com/vidfriends/backend/internal/repositories"
 )
 
 // AuthHandler implements user authentication endpoints.
 type AuthHandler struct {
-	Users UserStore
+	Users    UserStore
+	Sessions SessionManager
+	NowFunc  func() time.Time
 }
 
 // Login handles POST /api/v1/auth/login requests.
@@ -17,9 +30,41 @@ func (h AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respondJSON(w, http.StatusNotImplemented, map[string]string{
-		"message": "login not yet implemented",
-	})
+	if h.Users == nil || h.Sessions == nil {
+		respondJSON(w, http.StatusInternalServerError, map[string]string{"error": "authentication services unavailable"})
+		return
+	}
+
+	var req loginRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	req.Email = strings.TrimSpace(strings.ToLower(req.Email))
+	if req.Email == "" || req.Password == "" {
+		respondJSON(w, http.StatusBadRequest, map[string]string{"error": "email and password are required"})
+		return
+	}
+
+	user, err := h.Users.FindByEmail(r.Context(), req.Email)
+	if err != nil {
+		respondJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid credentials"})
+		return
+	}
+
+	if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(req.Password)); err != nil {
+		respondJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid credentials"})
+		return
+	}
+
+	tokens, err := h.Sessions.Issue(r.Context(), user.ID)
+	if err != nil {
+		respondJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create session"})
+		return
+	}
+
+	respondJSON(w, http.StatusOK, authResponse{Tokens: tokens})
 }
 
 // SignUp handles POST /api/v1/auth/signup requests.
@@ -29,9 +74,136 @@ func (h AuthHandler) SignUp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respondJSON(w, http.StatusNotImplemented, map[string]string{
-		"message": "signup not yet implemented",
-	})
+	if h.Users == nil || h.Sessions == nil {
+		respondJSON(w, http.StatusInternalServerError, map[string]string{"error": "authentication services unavailable"})
+		return
+	}
+
+	var req signUpRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	req.Email = strings.TrimSpace(strings.ToLower(req.Email))
+	if req.Email == "" || req.Password == "" {
+		respondJSON(w, http.StatusBadRequest, map[string]string{"error": "email and password are required"})
+		return
+	}
+
+	if _, err := mail.ParseAddress(req.Email); err != nil {
+		respondJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid email address"})
+		return
+	}
+
+	if len(req.Password) < 8 {
+		respondJSON(w, http.StatusBadRequest, map[string]string{"error": "password must be at least 8 characters"})
+		return
+	}
+
+	if _, err := h.Users.FindByEmail(r.Context(), req.Email); err == nil {
+		respondJSON(w, http.StatusConflict, map[string]string{"error": "account already exists"})
+		return
+	} else if err != nil && !errors.Is(err, repositories.ErrNotFound) {
+		respondJSON(w, http.StatusInternalServerError, map[string]string{"error": "unable to verify existing accounts"})
+		return
+	}
+
+	hashed, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+	if err != nil {
+		respondJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to secure password"})
+		return
+	}
+
+	now := h.now()
+	user := models.User{
+		ID:        uuid.NewString(),
+		Email:     req.Email,
+		Password:  string(hashed),
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	if err := h.Users.Create(r.Context(), user); err != nil {
+		if errors.Is(err, repositories.ErrConflict) {
+			respondJSON(w, http.StatusConflict, map[string]string{"error": "account already exists"})
+			return
+		}
+		respondJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create account"})
+		return
+	}
+
+	tokens, err := h.Sessions.Issue(r.Context(), user.ID)
+	if err != nil {
+		respondJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create session"})
+		return
+	}
+
+	respondJSON(w, http.StatusCreated, authResponse{Tokens: tokens})
+}
+
+// Refresh exchanges a refresh token for a new session.
+func (h AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	if h.Sessions == nil {
+		respondJSON(w, http.StatusInternalServerError, map[string]string{"error": "session service unavailable"})
+		return
+	}
+
+	var req refreshRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	req.RefreshToken = strings.TrimSpace(req.RefreshToken)
+	if req.RefreshToken == "" {
+		respondJSON(w, http.StatusBadRequest, map[string]string{"error": "refresh token is required"})
+		return
+	}
+
+	tokens, err := h.Sessions.Refresh(r.Context(), req.RefreshToken)
+	if err != nil {
+		status := http.StatusUnauthorized
+		if errors.Is(err, auth.ErrRefreshTokenExpired) || errors.Is(err, auth.ErrSessionNotFound) {
+			status = http.StatusUnauthorized
+		} else {
+			status = http.StatusInternalServerError
+		}
+		respondJSON(w, status, map[string]string{"error": "unable to refresh session"})
+		return
+	}
+
+	respondJSON(w, http.StatusOK, authResponse{Tokens: tokens})
+}
+
+type loginRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type signUpRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type refreshRequest struct {
+	RefreshToken string `json:"refreshToken"`
+}
+
+type authResponse struct {
+	Tokens models.SessionTokens `json:"tokens"`
+}
+
+func (h AuthHandler) now() time.Time {
+	if h.NowFunc != nil {
+		return h.NowFunc()
+	}
+	return time.Now().UTC()
 }
 
 func respondJSON(w http.ResponseWriter, status int, payload any) {

--- a/backend/internal/handlers/auth_test.go
+++ b/backend/internal/handlers/auth_test.go
@@ -1,0 +1,148 @@
+package handlers
+
+import (
+        "bytes"
+        "context"
+        "encoding/json"
+        "net/http"
+        "net/http/httptest"
+        "testing"
+        "time"
+
+        "golang.org/x/crypto/bcrypt"
+
+        "github.com/vidfriends/backend/internal/auth"
+        "github.com/vidfriends/backend/internal/models"
+        "github.com/vidfriends/backend/internal/repositories"
+)
+
+type inMemoryUserStore struct {
+        users map[string]models.User
+}
+
+func newInMemoryUserStore() *inMemoryUserStore {
+        return &inMemoryUserStore{users: make(map[string]models.User)}
+}
+
+func (s *inMemoryUserStore) Create(_ context.Context, user models.User) error {
+        if _, exists := s.users[user.Email]; exists {
+                return repositories.ErrConflict
+        }
+        s.users[user.Email] = user
+        return nil
+}
+
+func (s *inMemoryUserStore) FindByEmail(_ context.Context, email string) (models.User, error) {
+        user, ok := s.users[email]
+        if !ok {
+                return models.User{}, repositories.ErrNotFound
+        }
+        return user, nil
+}
+
+func TestAuthHandlerSignUp(t *testing.T) {
+        store := newInMemoryUserStore()
+        manager := auth.NewManager(time.Minute, time.Hour)
+        handler := AuthHandler{Users: store, Sessions: manager}
+
+        body, err := json.Marshal(signUpRequest{Email: "test@example.com", Password: "supersafe"})
+        if err != nil {
+                t.Fatalf("marshal: %v", err)
+        }
+
+        req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/signup", bytes.NewReader(body))
+        rec := httptest.NewRecorder()
+
+        handler.SignUp(rec, req)
+
+        if rec.Code != http.StatusCreated {
+                t.Fatalf("expected status %d got %d", http.StatusCreated, rec.Code)
+        }
+
+        var resp authResponse
+        if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+                t.Fatalf("decode response: %v", err)
+        }
+
+        if resp.Tokens.AccessToken == "" || resp.Tokens.RefreshToken == "" {
+                t.Fatalf("expected tokens to be issued, got %+v", resp.Tokens)
+        }
+
+        stored, err := store.FindByEmail(context.Background(), "test@example.com")
+        if err != nil {
+                t.Fatalf("expected user to be stored: %v", err)
+        }
+
+        if bcrypt.CompareHashAndPassword([]byte(stored.Password), []byte("supersafe")) != nil {
+                t.Fatal("stored password is not hashed")
+        }
+}
+
+func TestAuthHandlerLogin(t *testing.T) {
+        store := newInMemoryUserStore()
+        manager := auth.NewManager(time.Minute, time.Hour)
+        handler := AuthHandler{Users: store, Sessions: manager}
+
+        hashed, err := bcrypt.GenerateFromPassword([]byte("password123"), bcrypt.DefaultCost)
+        if err != nil {
+                t.Fatalf("hash password: %v", err)
+        }
+
+        store.users["login@example.com"] = models.User{ID: "user-1", Email: "login@example.com", Password: string(hashed)}
+
+        body, err := json.Marshal(loginRequest{Email: "login@example.com", Password: "password123"})
+        if err != nil {
+                t.Fatalf("marshal: %v", err)
+        }
+
+        req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", bytes.NewReader(body))
+        rec := httptest.NewRecorder()
+
+        handler.Login(rec, req)
+
+        if rec.Code != http.StatusOK {
+                t.Fatalf("expected status %d got %d", http.StatusOK, rec.Code)
+        }
+
+        var resp authResponse
+        if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+                t.Fatalf("decode response: %v", err)
+        }
+
+        if resp.Tokens.AccessToken == "" || resp.Tokens.RefreshToken == "" {
+                t.Fatalf("expected tokens to be issued, got %+v", resp.Tokens)
+        }
+}
+
+func TestAuthHandlerRefresh(t *testing.T) {
+        manager := auth.NewManager(time.Minute, time.Hour)
+        tokens, err := manager.Issue(context.Background(), "user-123")
+        if err != nil {
+                t.Fatalf("issue tokens: %v", err)
+        }
+
+        handler := AuthHandler{Sessions: manager}
+
+        body, err := json.Marshal(refreshRequest{RefreshToken: tokens.RefreshToken})
+        if err != nil {
+                t.Fatalf("marshal: %v", err)
+        }
+
+        req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/refresh", bytes.NewReader(body))
+        rec := httptest.NewRecorder()
+
+        handler.Refresh(rec, req)
+
+        if rec.Code != http.StatusOK {
+                t.Fatalf("expected status %d got %d", http.StatusOK, rec.Code)
+        }
+
+        var resp authResponse
+        if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+                t.Fatalf("decode response: %v", err)
+        }
+
+        if resp.Tokens.RefreshToken == tokens.RefreshToken {
+                t.Fatal("expected a new refresh token to be issued")
+        }
+}

--- a/backend/internal/handlers/interfaces.go
+++ b/backend/internal/handlers/interfaces.go
@@ -12,6 +12,12 @@ type UserStore interface {
 	FindByEmail(ctx context.Context, email string) (models.User, error)
 }
 
+// SessionManager issues and refreshes authentication tokens for users.
+type SessionManager interface {
+	Issue(ctx context.Context, userID string) (models.SessionTokens, error)
+	Refresh(ctx context.Context, refreshToken string) (models.SessionTokens, error)
+}
+
 // FriendStore captures operations required by the friend handlers.
 type FriendStore interface {
 	CreateRequest(ctx context.Context, request models.FriendRequest) error

--- a/backend/internal/handlers/routes.go
+++ b/backend/internal/handlers/routes.go
@@ -5,13 +5,14 @@ import "net/http"
 // RegisterRoutes wires HTTP handlers into the provided ServeMux.
 func RegisterRoutes(mux *http.ServeMux, deps Dependencies) {
 	health := HealthHandler{}
-	auth := AuthHandler{Users: deps.Users}
+	auth := AuthHandler{Users: deps.Users, Sessions: deps.Sessions}
 	friends := FriendHandler{Friends: deps.Friends}
 	videos := VideoHandler{Videos: deps.Videos}
 
 	mux.HandleFunc("/healthz", health.Handle)
 	mux.HandleFunc("/api/v1/auth/login", auth.Login)
 	mux.HandleFunc("/api/v1/auth/signup", auth.SignUp)
+	mux.HandleFunc("/api/v1/auth/refresh", auth.Refresh)
 	mux.HandleFunc("/api/v1/friends", friends.List)
 	mux.HandleFunc("/api/v1/friends/invite", friends.Invite)
 	mux.HandleFunc("/api/v1/videos", videos.Create)
@@ -20,7 +21,8 @@ func RegisterRoutes(mux *http.ServeMux, deps Dependencies) {
 
 // Dependencies aggregates collaborators required by HTTP handlers.
 type Dependencies struct {
-	Users   UserStore
-	Friends FriendStore
-	Videos  VideoStore
+	Users    UserStore
+	Sessions SessionManager
+	Friends  FriendStore
+	Videos   VideoStore
 }

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -31,3 +31,11 @@ type VideoShare struct {
 	Thumbnail   string
 	CreatedAt   time.Time
 }
+
+// SessionTokens groups the bearer credentials issued to authenticated users.
+type SessionTokens struct {
+	AccessToken      string
+	AccessExpiresAt  time.Time
+	RefreshToken     string
+	RefreshExpiresAt time.Time
+}

--- a/backend/internal/repositories/errors.go
+++ b/backend/internal/repositories/errors.go
@@ -1,0 +1,10 @@
+package repositories
+
+import "errors"
+
+var (
+	// ErrNotFound indicates the requested record does not exist.
+	ErrNotFound = errors.New("record not found")
+	// ErrConflict indicates the attempted write would violate a uniqueness constraint.
+	ErrConflict = errors.New("record conflict")
+)


### PR DESCRIPTION
## Summary
- add an in-memory session manager and shared session token model for authentication flows
- implement signup, login, and refresh handlers with validation, persistence error handling, and coverage tests
- expose the auth refresh route, wire a default session manager, and mark the TODO item complete

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4ca9f10f4832f97b8410337136528