### PR TITLE
Implement friend management APIs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@ A living checklist of follow-up work and enhancements to guide ongoing developme
 ## Backend
 - [x] Flesh out the Go project structure under `backend/` with handlers, data models, and migrations.
 - [x] Implement authentication endpoints, including session management and token refresh.
-- [ ] Add friend management APIs (invite, accept, block) with appropriate database migrations.
+- [x] Add friend management APIs (invite, accept, block) with appropriate database migrations.
 - [ ] Integrate yt-dlp metadata lookups for shared video links and cache results.
 - [ ] Write comprehensive Go tests for handlers, repositories, and domain logic.
 

--- a/backend/internal/handlers/friends.go
+++ b/backend/internal/handlers/friends.go
@@ -1,10 +1,28 @@
 package handlers
 
-import "net/http"
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/vidfriends/backend/internal/models"
+	"github.com/vidfriends/backend/internal/repositories"
+)
+
+const (
+	friendStatusPending  = "pending"
+	friendStatusAccepted = "accepted"
+	friendStatusBlocked  = "blocked"
+)
 
 // FriendHandler provides friend invite and listing endpoints.
 type FriendHandler struct {
 	Friends FriendStore
+	NowFunc func() time.Time
 }
 
 // Invite handles POST /api/v1/friends/invite.
@@ -14,9 +32,52 @@ func (h FriendHandler) Invite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respondJSON(w, http.StatusNotImplemented, map[string]string{
-		"message": "friend invite not yet implemented",
-	})
+	if h.Friends == nil {
+		respondJSON(w, http.StatusInternalServerError, map[string]string{"error": "friend service unavailable"})
+		return
+	}
+
+	var req inviteFriendRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	req.RequesterID = strings.TrimSpace(req.RequesterID)
+	req.ReceiverID = strings.TrimSpace(req.ReceiverID)
+
+	if req.RequesterID == "" || req.ReceiverID == "" {
+		respondJSON(w, http.StatusBadRequest, map[string]string{"error": "requesterId and receiverId are required"})
+		return
+	}
+
+	if req.RequesterID == req.ReceiverID {
+		respondJSON(w, http.StatusBadRequest, map[string]string{"error": "cannot invite yourself"})
+		return
+	}
+
+	now := h.now()
+	friendReq := models.FriendRequest{
+		ID:        uuid.NewString(),
+		Requester: req.RequesterID,
+		Receiver:  req.ReceiverID,
+		Status:    friendStatusPending,
+		CreatedAt: now,
+	}
+
+	if err := h.Friends.CreateRequest(r.Context(), friendReq); err != nil {
+		switch {
+		case errors.Is(err, repositories.ErrConflict):
+			respondJSON(w, http.StatusConflict, map[string]string{"error": "friend request already exists"})
+		case errors.Is(err, repositories.ErrNotFound):
+			respondJSON(w, http.StatusNotFound, map[string]string{"error": "user not found"})
+		default:
+			respondJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create friend request"})
+		}
+		return
+	}
+
+	respondJSON(w, http.StatusCreated, friendRequestResponse{Request: friendReq})
 }
 
 // List handles GET /api/v1/friends requests.
@@ -26,7 +87,98 @@ func (h FriendHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respondJSON(w, http.StatusNotImplemented, map[string]string{
-		"message": "friend listing not yet implemented",
+	if h.Friends == nil {
+		respondJSON(w, http.StatusInternalServerError, map[string]string{"error": "friend service unavailable"})
+		return
+	}
+
+	userID := strings.TrimSpace(r.URL.Query().Get("user"))
+	if userID == "" {
+		respondJSON(w, http.StatusBadRequest, map[string]string{"error": "user query parameter is required"})
+		return
+	}
+
+	requests, err := h.Friends.ListForUser(r.Context(), userID)
+	if err != nil {
+		respondJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list friend requests"})
+		return
+	}
+
+	respondJSON(w, http.StatusOK, listFriendsResponse{Requests: requests})
+}
+
+// Respond handles POST /api/v1/friends/respond requests to accept or block invites.
+func (h FriendHandler) Respond(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	if h.Friends == nil {
+		respondJSON(w, http.StatusInternalServerError, map[string]string{"error": "friend service unavailable"})
+		return
+	}
+
+	var req respondFriendRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	req.RequestID = strings.TrimSpace(req.RequestID)
+	action := strings.ToLower(strings.TrimSpace(req.Action))
+	if req.RequestID == "" || action == "" {
+		respondJSON(w, http.StatusBadRequest, map[string]string{"error": "requestId and action are required"})
+		return
+	}
+
+	var status string
+	switch action {
+	case "accept":
+		status = friendStatusAccepted
+	case "block":
+		status = friendStatusBlocked
+	default:
+		respondJSON(w, http.StatusBadRequest, map[string]string{"error": "action must be accept or block"})
+		return
+	}
+
+	if err := h.Friends.UpdateStatus(r.Context(), req.RequestID, status); err != nil {
+		if errors.Is(err, repositories.ErrNotFound) {
+			respondJSON(w, http.StatusNotFound, map[string]string{"error": "friend request not found"})
+			return
+		}
+		respondJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to update friend request"})
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]string{
+		"requestId": req.RequestID,
+		"status":    status,
 	})
+}
+
+func (h FriendHandler) now() time.Time {
+	if h.NowFunc != nil {
+		return h.NowFunc()
+	}
+	return time.Now().UTC()
+}
+
+type inviteFriendRequest struct {
+	RequesterID string `json:"requesterId"`
+	ReceiverID  string `json:"receiverId"`
+}
+
+type respondFriendRequest struct {
+	RequestID string `json:"requestId"`
+	Action    string `json:"action"`
+}
+
+type friendRequestResponse struct {
+	Request models.FriendRequest `json:"request"`
+}
+
+type listFriendsResponse struct {
+	Requests []models.FriendRequest `json:"requests"`
 }

--- a/backend/internal/handlers/friends_test.go
+++ b/backend/internal/handlers/friends_test.go
@@ -1,0 +1,144 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/vidfriends/backend/internal/models"
+	"github.com/vidfriends/backend/internal/repositories"
+)
+
+type inMemoryFriendStore struct {
+	requests map[string]models.FriendRequest
+}
+
+func newInMemoryFriendStore() *inMemoryFriendStore {
+	return &inMemoryFriendStore{requests: make(map[string]models.FriendRequest)}
+}
+
+func (s *inMemoryFriendStore) CreateRequest(_ context.Context, request models.FriendRequest) error {
+	for _, existing := range s.requests {
+		if existing.Requester == request.Requester && existing.Receiver == request.Receiver {
+			return repositories.ErrConflict
+		}
+	}
+	s.requests[request.ID] = request
+	return nil
+}
+
+func (s *inMemoryFriendStore) ListForUser(_ context.Context, userID string) ([]models.FriendRequest, error) {
+	var out []models.FriendRequest
+	for _, request := range s.requests {
+		if request.Requester == userID || request.Receiver == userID {
+			out = append(out, request)
+		}
+	}
+	return out, nil
+}
+
+func (s *inMemoryFriendStore) UpdateStatus(_ context.Context, requestID, status string) error {
+	request, ok := s.requests[requestID]
+	if !ok {
+		return repositories.ErrNotFound
+	}
+	request.Status = status
+	respondedAt := time.Now().UTC()
+	request.RespondedAt = &respondedAt
+	s.requests[requestID] = request
+	return nil
+}
+
+func TestFriendHandlerInvite(t *testing.T) {
+	store := newInMemoryFriendStore()
+	now := time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
+	handler := FriendHandler{Friends: store, NowFunc: func() time.Time { return now }}
+
+	body, err := json.Marshal(inviteFriendRequest{RequesterID: "user-1", ReceiverID: "user-2"})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/friends/invite", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	handler.Invite(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected status %d got %d", http.StatusCreated, rec.Code)
+	}
+
+	var resp friendRequestResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if resp.Request.Status != friendStatusPending {
+		t.Fatalf("expected status %q got %q", friendStatusPending, resp.Request.Status)
+	}
+
+	if resp.Request.CreatedAt != now {
+		t.Fatalf("expected createdAt to use NowFunc")
+	}
+
+	if _, ok := store.requests[resp.Request.ID]; !ok {
+		t.Fatalf("expected request to be stored")
+	}
+}
+
+func TestFriendHandlerList(t *testing.T) {
+	store := newInMemoryFriendStore()
+	store.requests["req-1"] = models.FriendRequest{ID: "req-1", Requester: "user-1", Receiver: "user-2", Status: friendStatusPending}
+	handler := FriendHandler{Friends: store}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/friends?user=user-1", nil)
+	rec := httptest.NewRecorder()
+
+	handler.List(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d got %d", http.StatusOK, rec.Code)
+	}
+
+	var resp listFriendsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if len(resp.Requests) != 1 || resp.Requests[0].ID != "req-1" {
+		t.Fatalf("unexpected response payload: %+v", resp)
+	}
+}
+
+func TestFriendHandlerRespond(t *testing.T) {
+	store := newInMemoryFriendStore()
+	store.requests["req-1"] = models.FriendRequest{ID: "req-1", Requester: "user-1", Receiver: "user-2", Status: friendStatusPending}
+	handler := FriendHandler{Friends: store}
+
+	body, err := json.Marshal(respondFriendRequest{RequestID: "req-1", Action: "accept"})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/friends/respond", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	handler.Respond(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d got %d", http.StatusOK, rec.Code)
+	}
+
+	updated := store.requests["req-1"]
+	if updated.Status != friendStatusAccepted {
+		t.Fatalf("expected status %q got %q", friendStatusAccepted, updated.Status)
+	}
+
+	if updated.RespondedAt == nil {
+		t.Fatalf("expected respondedAt to be set")
+	}
+}

--- a/backend/internal/handlers/interfaces.go
+++ b/backend/internal/handlers/interfaces.go
@@ -22,6 +22,7 @@ type SessionManager interface {
 type FriendStore interface {
 	CreateRequest(ctx context.Context, request models.FriendRequest) error
 	ListForUser(ctx context.Context, userID string) ([]models.FriendRequest, error)
+	UpdateStatus(ctx context.Context, requestID, status string) error
 }
 
 // VideoStore captures persistence for video sharing workflows.

--- a/backend/internal/handlers/routes.go
+++ b/backend/internal/handlers/routes.go
@@ -15,6 +15,7 @@ func RegisterRoutes(mux *http.ServeMux, deps Dependencies) {
 	mux.HandleFunc("/api/v1/auth/refresh", auth.Refresh)
 	mux.HandleFunc("/api/v1/friends", friends.List)
 	mux.HandleFunc("/api/v1/friends/invite", friends.Invite)
+	mux.HandleFunc("/api/v1/friends/respond", friends.Respond)
 	mux.HandleFunc("/api/v1/videos", videos.Create)
 	mux.HandleFunc("/api/v1/videos/feed", videos.Feed)
 }

--- a/backend/migrations/0002_friend_request_constraints.sql
+++ b/backend/migrations/0002_friend_request_constraints.sql
@@ -1,0 +1,13 @@
+-- 0002_friend_request_constraints.sql
+-- Enforce friend request status values and uniqueness constraints.
+
+BEGIN;
+
+ALTER TABLE friend_requests
+    ADD CONSTRAINT friend_requests_status_check CHECK (status IN ('pending', 'accepted', 'blocked')),
+    ADD CONSTRAINT friend_requests_unique_pair UNIQUE (requester_id, receiver_id);
+
+CREATE INDEX IF NOT EXISTS friend_requests_receiver_idx ON friend_requests (receiver_id);
+CREATE INDEX IF NOT EXISTS friend_requests_requester_idx ON friend_requests (requester_id);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- implement friend invitation, listing, and response endpoints with validation and status transitions
- extend friend handler interfaces, add dedicated tests, and expose new respond route
- add database constraints for friend requests and update TODO to reflect completed work

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4cd04d3e8832f81a0fbfb873aa7d2