### PR TITLE
Design shared video feed with reactions and filters

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,7 @@ A living checklist of follow-up work and enhancements to guide ongoing developme
 - [x] Scaffold the React + TypeScript application under `frontend/` with routing and global state management.
 - [x] Implement authentication flows (signup, login, password reset) against the backend APIs.
  - [x] Build friend list management UI with optimistic updates and error handling.
-- [ ] Design the shared video feed with metadata display, reactions, and filtering.
+- [x] Design the shared video feed with metadata display, reactions, and filtering.
 - [ ] Add frontend unit and integration tests covering critical user journeys.
 
 ## Documentation

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { useAppState } from '../state/useAppState';
 import { FriendListManager } from './components/FriendListManager';
+import { VideoFeedPanel } from './components/VideoFeedPanel';
 
 export function DashboardPage() {
   const { auth, feed } = useAppState();
@@ -32,60 +33,7 @@ export function DashboardPage() {
       >
         <FriendListManager />
 
-        <article
-          aria-label="Shared video feed"
-          style={{
-            backgroundColor: 'rgba(15, 23, 42, 0.85)',
-            padding: '1.75rem',
-            borderRadius: '1rem',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '1.25rem',
-            boxShadow: '0 25px 40px -24px rgba(15, 23, 42, 0.7)'
-          }}
-        >
-          <div>
-            <h3 style={{ marginBottom: '0.5rem' }}>Shared videos</h3>
-            <p style={{ color: 'rgba(148, 163, 184, 0.85)', fontSize: '0.9rem' }}>
-              Keep up with the latest videos from friends and jump into conversations.
-            </p>
-          </div>
-          {feed.entries.length === 0 ? (
-            <p style={{ color: 'rgba(148, 163, 184, 0.85)' }}>
-              Share a link to see it appear here.
-            </p>
-          ) : (
-            <ul style={{ listStyle: 'none', padding: 0, display: 'grid', gap: '1rem' }}>
-              {feed.entries.map((entry) => (
-                <li
-                  key={entry.id}
-                  style={{
-                    backgroundColor: 'rgba(15, 23, 42, 0.6)',
-                    border: '1px solid rgba(148, 163, 184, 0.2)',
-                    borderRadius: '0.85rem',
-                    padding: '1rem 1.25rem',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: '0.35rem'
-                  }}
-                >
-                  <p style={{ fontWeight: 600 }}>{entry.title}</p>
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
-                    <p style={{ fontSize: '0.85rem', color: 'rgba(148, 163, 184, 0.9)' }}>
-                      Shared by {entry.sharedBy}
-                    </p>
-                    <time
-                      dateTime={entry.sharedAt}
-                      style={{ fontSize: '0.75rem', color: 'rgba(148, 163, 184, 0.7)' }}
-                    >
-                      {new Date(entry.sharedAt).toLocaleString()}
-                    </time>
-                  </div>
-                </li>
-              ))}
-            </ul>
-          )}
-        </article>
+        <VideoFeedPanel feed={feed} />
       </div>
     </section>
   );

--- a/frontend/src/pages/components/VideoFeedPanel.tsx
+++ b/frontend/src/pages/components/VideoFeedPanel.tsx
@@ -1,0 +1,329 @@
+import { useMemo, useState } from 'react';
+
+import type { FeedEntry, ReactionType } from '../../state/AppStateProvider';
+import { useAppState } from '../../state/useAppState';
+
+type FeedFilter = 'all' | 'recent' | 'friends-online' | 'trending' | `tag:${string}`;
+
+type VideoFeedPanelProps = {
+  feed: { entries: FeedEntry[] };
+};
+
+const reactionConfig: Array<{ type: ReactionType; label: string; icon: string }> = [
+  { type: 'like', label: 'Like', icon: '👍' },
+  { type: 'love', label: 'Love', icon: '❤️' },
+  { type: 'wow', label: 'Wow', icon: '🤯' },
+  { type: 'laugh', label: 'Laugh', icon: '😂' }
+];
+
+export function VideoFeedPanel({ feed }: VideoFeedPanelProps) {
+  const { friends, reactToVideo } = useAppState();
+  const [activeFilter, setActiveFilter] = useState<FeedFilter>('all');
+
+  const onlineFriendNames = useMemo(
+    () => new Set(friends.connections.filter((friend) => friend.status !== 'offline').map((friend) => friend.displayName)),
+    [friends.connections]
+  );
+
+  const filterOptions = useMemo(() => {
+    const uniqueTags = new Set<string>();
+    feed.entries.forEach((entry) => {
+      entry.tags.forEach((tag) => uniqueTags.add(tag));
+    });
+    const tags = Array.from(uniqueTags).sort((a, b) => a.localeCompare(b));
+    return [
+      { id: 'all' as FeedFilter, label: 'All' },
+      { id: 'recent' as FeedFilter, label: 'Recent' },
+      { id: 'trending' as FeedFilter, label: 'Trending' },
+      { id: 'friends-online' as FeedFilter, label: 'From Online Friends' },
+      ...tags.map((tag) => ({ id: `tag:${tag}` as FeedFilter, label: tag }))
+    ];
+  }, [feed.entries]);
+
+  const filteredEntries = useMemo(() => {
+    const entries = [...feed.entries];
+    const now = Date.now();
+
+    switch (activeFilter) {
+      case 'recent':
+        return entries
+          .filter((entry) => now - new Date(entry.sharedAt).getTime() <= 1000 * 60 * 60 * 24 * 2)
+          .sort((a, b) => new Date(b.sharedAt).getTime() - new Date(a.sharedAt).getTime());
+      case 'trending':
+        return entries
+          .filter((entry) => totalReactions(entry) >= 10)
+          .sort((a, b) => totalReactions(b) - totalReactions(a));
+      case 'friends-online':
+        return entries
+          .filter((entry) => onlineFriendNames.has(entry.sharedBy))
+          .sort((a, b) => new Date(b.sharedAt).getTime() - new Date(a.sharedAt).getTime());
+      default:
+        if (activeFilter.startsWith('tag:')) {
+          const tag = activeFilter.replace('tag:', '');
+          return entries
+            .filter((entry) => entry.tags.includes(tag))
+            .sort((a, b) => new Date(b.sharedAt).getTime() - new Date(a.sharedAt).getTime());
+        }
+        return entries.sort((a, b) => new Date(b.sharedAt).getTime() - new Date(a.sharedAt).getTime());
+    }
+  }, [activeFilter, feed.entries, onlineFriendNames]);
+
+  return (
+    <article
+      aria-label="Shared video feed"
+      style={{
+        backgroundColor: 'rgba(15, 23, 42, 0.85)',
+        padding: '1.75rem',
+        borderRadius: '1rem',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1.75rem',
+        boxShadow: '0 25px 40px -24px rgba(15, 23, 42, 0.7)'
+      }}
+    >
+      <header style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        <div>
+          <h3 style={{ marginBottom: '0.5rem' }}>Shared videos</h3>
+          <p style={{ color: 'rgba(148, 163, 184, 0.85)', fontSize: '0.9rem', maxWidth: '65ch' }}>
+            Dive into what your friends are sharing. Browse by momentum, who is online now, or the topics you care about most.
+          </p>
+        </div>
+
+        <nav aria-label="Filter shared videos" style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+          {filterOptions.map((filter) => (
+            <button
+              key={filter.id}
+              type="button"
+              onClick={() => setActiveFilter(filter.id)}
+              style={{
+                borderRadius: '9999px',
+                border: '1px solid rgba(148, 163, 184, 0.25)',
+                padding: '0.4rem 0.85rem',
+                backgroundColor: filter.id === activeFilter ? 'rgba(96, 165, 250, 0.16)' : 'rgba(15, 23, 42, 0.6)',
+                color: filter.id === activeFilter ? '#f8fafc' : 'rgba(148, 163, 184, 0.9)',
+                fontSize: '0.85rem',
+                transition: 'background-color 120ms ease, color 120ms ease'
+              }}
+            >
+              {filter.label}
+            </button>
+          ))}
+        </nav>
+      </header>
+
+      {filteredEntries.length === 0 ? (
+        <p style={{ color: 'rgba(148, 163, 184, 0.85)' }}>
+          Nothing here yet. Share a link or try a different filter to explore what your crew is watching.
+        </p>
+      ) : (
+        <ul style={{ listStyle: 'none', padding: 0, display: 'grid', gap: '1.25rem' }}>
+          {filteredEntries.map((entry) => (
+            <li key={entry.id}>
+              <VideoFeedCard entry={entry} onReact={reactToVideo} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </article>
+  );
+}
+
+type VideoFeedCardProps = {
+  entry: FeedEntry;
+  onReact: (entryId: string, reaction: ReactionType) => void;
+};
+
+function VideoFeedCard({ entry, onReact }: VideoFeedCardProps) {
+  const total = totalReactions(entry);
+  const formattedDuration = formatDuration(entry.durationSeconds);
+  const formattedViews = new Intl.NumberFormat('en', { notation: 'compact' }).format(entry.viewCount);
+
+  return (
+    <article
+      style={{
+        backgroundColor: 'rgba(15, 23, 42, 0.6)',
+        border: '1px solid rgba(148, 163, 184, 0.2)',
+        borderRadius: '1rem',
+        padding: '1.25rem',
+        display: 'grid',
+        gap: '1rem',
+        gridTemplateColumns: 'minmax(0, 240px) minmax(0, 1fr)'
+      }}
+    >
+      <a
+        href={entry.url}
+        target="_blank"
+        rel="noreferrer"
+        style={{
+          position: 'relative',
+          borderRadius: '0.85rem',
+          overflow: 'hidden',
+          display: 'block',
+          backgroundColor: '#0f172a'
+        }}
+      >
+        <img
+          src={entry.thumbnailUrl}
+          alt={`Preview for ${entry.title}`}
+          style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+          loading="lazy"
+        />
+        <span
+          style={{
+            position: 'absolute',
+            top: '0.75rem',
+            left: '0.75rem',
+            backgroundColor: 'rgba(15, 23, 42, 0.75)',
+            color: '#e2e8f0',
+            padding: '0.2rem 0.6rem',
+            borderRadius: '9999px',
+            fontSize: '0.7rem',
+            fontWeight: 600
+          }}
+        >
+          {entry.platform}
+        </span>
+        <span
+          style={{
+            position: 'absolute',
+            bottom: '0.75rem',
+            right: '0.75rem',
+            backgroundColor: 'rgba(15, 23, 42, 0.75)',
+            color: '#f8fafc',
+            padding: '0.2rem 0.6rem',
+            borderRadius: '0.35rem',
+            fontSize: '0.75rem',
+            fontVariantNumeric: 'tabular-nums'
+          }}
+        >
+          {formattedDuration}
+        </span>
+      </a>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.65rem' }}>
+        <header style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
+            <h4 style={{ margin: 0 }}>{entry.title}</h4>
+            <time
+              dateTime={entry.sharedAt}
+              style={{ fontSize: '0.75rem', color: 'rgba(148, 163, 184, 0.7)' }}
+              title={new Date(entry.sharedAt).toLocaleString()}
+            >
+              {formatRelativeTime(entry.sharedAt)}
+            </time>
+          </div>
+          <p style={{ fontSize: '0.85rem', color: 'rgba(148, 163, 184, 0.85)' }}>
+            Shared by <strong style={{ color: '#f8fafc' }}>{entry.sharedBy}</strong> · {entry.channelName}
+          </p>
+        </header>
+
+        <p style={{ color: 'rgba(203, 213, 225, 0.9)', fontSize: '0.9rem', lineHeight: 1.5 }}>
+          {entry.description}
+        </p>
+
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+          {entry.tags.map((tag) => (
+            <span
+              key={tag}
+              style={{
+                fontSize: '0.7rem',
+                padding: '0.25rem 0.65rem',
+                backgroundColor: 'rgba(96, 165, 250, 0.1)',
+                border: '1px solid rgba(96, 165, 250, 0.15)',
+                borderRadius: '999px',
+                color: 'rgba(191, 219, 254, 0.95)'
+              }}
+            >
+              #{tag}
+            </span>
+          ))}
+        </div>
+
+        <footer
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            gap: '0.75rem'
+          }}
+        >
+          <div style={{ display: 'flex', gap: '0.35rem', flexWrap: 'wrap' }}>
+            {reactionConfig.map((reaction) => {
+              const isActive = entry.userReaction === reaction.type;
+              return (
+                <button
+                  key={reaction.type}
+                  type="button"
+                  onClick={() => onReact(entry.id, reaction.type)}
+                  aria-pressed={isActive}
+                  title={`${reaction.label} reaction`}
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: '0.35rem',
+                    borderRadius: '9999px',
+                    border: '1px solid rgba(148, 163, 184, 0.25)',
+                    backgroundColor: isActive ? 'rgba(59, 130, 246, 0.2)' : 'rgba(15, 23, 42, 0.5)',
+                    color: isActive ? '#f8fafc' : 'rgba(203, 213, 225, 0.95)',
+                    padding: '0.35rem 0.75rem',
+                    fontSize: '0.8rem',
+                    cursor: 'pointer',
+                    transition: 'background-color 120ms ease, transform 120ms ease'
+                  }}
+                >
+                  <span aria-hidden="true">{reaction.icon}</span>
+                  <span>{entry.reactions[reaction.type] ?? 0}</span>
+                </button>
+              );
+            })}
+          </div>
+
+          <p style={{ margin: 0, fontSize: '0.8rem', color: 'rgba(148, 163, 184, 0.85)' }}>
+            {formattedViews} views · {total} reactions
+          </p>
+        </footer>
+      </div>
+    </article>
+  );
+}
+
+function totalReactions(entry: FeedEntry) {
+  return Object.values(entry.reactions).reduce((sum, value) => sum + (value ?? 0), 0);
+}
+
+function formatDuration(durationSeconds: number) {
+  const minutes = Math.floor(durationSeconds / 60);
+  const seconds = durationSeconds % 60;
+  const hours = Math.floor(minutes / 60);
+  const minutesWithinHour = minutes % 60;
+
+  const parts = [] as string[];
+  if (hours > 0) {
+    parts.push(String(hours));
+    parts.push(minutesWithinHour.toString().padStart(2, '0'));
+  } else {
+    parts.push(minutes.toString());
+  }
+  parts.push(seconds.toString().padStart(2, '0'));
+  return parts.join(':');
+}
+
+function formatRelativeTime(timestamp: string) {
+  const diff = Date.now() - new Date(timestamp).getTime();
+  const units: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+    ['day', 1000 * 60 * 60 * 24],
+    ['hour', 1000 * 60 * 60],
+    ['minute', 1000 * 60],
+    ['second', 1000]
+  ];
+  const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+  for (const [unit, ms] of units) {
+    if (Math.abs(diff) >= ms || unit === 'second') {
+      const value = Math.round(diff / ms);
+      return rtf.format(-value, unit);
+    }
+  }
+  return 'just now';
+}

--- a/frontend/src/state/AppStateProvider.tsx
+++ b/frontend/src/state/AppStateProvider.tsx
@@ -166,11 +166,23 @@ export interface FriendConnection {
   status: 'online' | 'offline' | 'away';
 }
 
+export type ReactionType = 'like' | 'love' | 'wow' | 'laugh';
+
 export interface FeedEntry {
   id: string;
   title: string;
   sharedBy: string;
   sharedAt: string;
+  platform: string;
+  url: string;
+  thumbnailUrl: string;
+  channelName: string;
+  durationSeconds: number;
+  viewCount: number;
+  description: string;
+  tags: string[];
+  reactions: Record<ReactionType, number>;
+  userReaction: ReactionType | null;
 }
 
 interface AuthState {
@@ -197,7 +209,8 @@ type AppStateAction =
   | { type: 'add-invite'; payload: FriendInvite }
   | { type: 'resolve-invite'; payload: { inviteId: string; accepted: boolean } }
   | { type: 'remove-friend'; payload: { friendId: string } }
-  | { type: 'share-video'; payload: FeedEntry };
+  | { type: 'share-video'; payload: FeedEntry }
+  | { type: 'react-to-video'; payload: { entryId: string; reaction: ReactionType } };
 
 const initialState: AppState = {
   auth: {
@@ -221,7 +234,52 @@ const initialState: AppState = {
         id: 'feed-1',
         title: 'Top 10 Cozy Indie Games',
         sharedBy: 'Rowan Carter',
-        sharedAt: new Date().toISOString()
+        sharedAt: new Date(Date.now() - 1000 * 60 * 35).toISOString(),
+        platform: 'YouTube',
+        url: 'https://www.youtube.com/watch?v=I6-hm4DYPwU',
+        thumbnailUrl: 'https://i.ytimg.com/vi/I6-hm4DYPwU/hqdefault.jpg',
+        channelName: 'Indie Realm',
+        durationSeconds: 972,
+        viewCount: 48200,
+        description:
+          'Discover new cozy titles perfect for winding down after a long day. This curated list covers hidden gems, heartfelt stories, and soundtracks you will want on repeat.',
+        tags: ['Games', 'Cozy', 'Indie'],
+        reactions: { like: 18, love: 6, wow: 2, laugh: 1 },
+        userReaction: null
+      },
+      {
+        id: 'feed-2',
+        title: 'Morning Flow Yoga for Beginners',
+        sharedBy: 'Priya Das',
+        sharedAt: new Date(Date.now() - 1000 * 60 * 60 * 5).toISOString(),
+        platform: 'YouTube',
+        url: 'https://www.youtube.com/watch?v=u5o593sW9DQ',
+        thumbnailUrl: 'https://i.ytimg.com/vi/u5o593sW9DQ/hqdefault.jpg',
+        channelName: 'Peaceful Moves',
+        durationSeconds: 1803,
+        viewCount: 91500,
+        description:
+          'A gentle yoga flow designed to wake up the body and focus the mind. No equipment required—perfect for easing into the day.',
+        tags: ['Wellness', 'Mindfulness', 'Beginner Friendly'],
+        reactions: { like: 12, love: 9, wow: 1, laugh: 0 },
+        userReaction: 'love'
+      },
+      {
+        id: 'feed-3',
+        title: 'How the JWST Sees the Universe',
+        sharedBy: 'Miguel Chen',
+        sharedAt: new Date(Date.now() - 1000 * 60 * 60 * 20).toISOString(),
+        platform: 'Nebula',
+        url: 'https://nebula.tv/videos/space-jwst',
+        thumbnailUrl: 'https://images.unsplash.com/photo-1581091226825-a6a2a5aee158?auto=format&fit=crop&w=1200&q=80',
+        channelName: 'Cosmic Perspectives',
+        durationSeconds: 1245,
+        viewCount: 38700,
+        description:
+          'Astrophysicist Dr. Mei Park breaks down the science behind the James Webb Space Telescope and what its discoveries mean for our understanding of deep space.',
+        tags: ['Science', 'Space', 'Documentary'],
+        reactions: { like: 21, love: 11, wow: 7, laugh: 0 },
+        userReaction: null
       }
     ]
   }
@@ -313,6 +371,37 @@ function appReducer(state: AppState, action: AppStateAction): AppState {
           entries: [action.payload, ...state.feed.entries]
         }
       };
+    case 'react-to-video': {
+      const { entryId, reaction } = action.payload;
+      return {
+        ...state,
+        feed: {
+          entries: state.feed.entries.map((entry) => {
+            if (entry.id !== entryId) {
+              return entry;
+            }
+
+            const nextReactions = { ...entry.reactions };
+            const currentReaction = entry.userReaction;
+            if (currentReaction) {
+              nextReactions[currentReaction] = Math.max(0, (nextReactions[currentReaction] ?? 0) - 1);
+            }
+
+            const togglingSameReaction = currentReaction === reaction;
+
+            if (!togglingSameReaction) {
+              nextReactions[reaction] = (nextReactions[reaction] ?? 0) + 1;
+            }
+
+            return {
+              ...entry,
+              reactions: nextReactions,
+              userReaction: togglingSameReaction ? null : reaction
+            };
+          })
+        }
+      };
+    }
     default:
       return state;
   }
@@ -326,7 +415,8 @@ export interface AppStateContextValue extends AppState {
   acceptInvite: (inviteId: string) => void;
   declineInvite: (inviteId: string) => void;
   respondToInvite: (inviteId: string, accepted: boolean) => Promise<void>;
-  shareVideo: (entry: Pick<FeedEntry, 'title'>) => void;
+  shareVideo: (entry: { title: string; url?: string }) => void;
+  reactToVideo: (entryId: string, reaction: ReactionType) => void;
 }
 
 const AppStateContext = createContext<AppStateContextValue | undefined>(undefined);
@@ -464,17 +554,36 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
 
   const shareVideo = useCallback<AppStateContextValue['shareVideo']>(
     (entry) => {
+      const title = entry.title.trim() || 'Untitled share';
+      const fallbackTags = deriveTagsFromTitle(title);
       dispatch({
         type: 'share-video',
         payload: {
           id: `feed-${Date.now()}`,
-          title: entry.title,
+          title,
           sharedBy: state.auth.user?.displayName ?? 'Anonymous friend',
-          sharedAt: new Date().toISOString()
+          sharedAt: new Date().toISOString(),
+          platform: inferPlatformFromUrl(entry.url),
+          url: entry.url ?? '#',
+          thumbnailUrl: generateThumbnailForTitle(title),
+          channelName: `${state.auth.user?.displayName ?? 'A VidFriend'}'s pick`,
+          durationSeconds: generateDurationForShare(),
+          viewCount: generateViewCount(),
+          description: `Shared by ${state.auth.user?.displayName ?? 'a friend'}: ${title}.`,
+          tags: fallbackTags,
+          reactions: { like: 0, love: 0, wow: 0, laugh: 0 },
+          userReaction: null
         }
       });
     },
     [state.auth.user?.displayName]
+  );
+
+  const reactToVideo = useCallback<AppStateContextValue['reactToVideo']>(
+    (entryId, reaction) => {
+      dispatch({ type: 'react-to-video', payload: { entryId, reaction } });
+    },
+    []
   );
 
   const contextValue = useMemo<AppStateContextValue>(
@@ -487,7 +596,8 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
       acceptInvite,
       declineInvite,
       respondToInvite,
-      shareVideo
+      shareVideo,
+      reactToVideo
     }),
     [
       state,
@@ -496,6 +606,7 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
       requestPasswordReset,
       respondToInvite,
       shareVideo,
+      reactToVideo,
       signIn,
       signOut,
       signUp
@@ -503,6 +614,80 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
   );
 
   return <AppStateContext.Provider value={contextValue}>{children}</AppStateContext.Provider>;
+}
+
+function inferPlatformFromUrl(url: string | undefined) {
+  if (!url) {
+    return 'Shared link';
+  }
+  const hostname = (() => {
+    try {
+      return new URL(url).hostname.replace('www.', '');
+    } catch (error) {
+      return '';
+    }
+  })();
+  if (!hostname) {
+    return 'Shared link';
+  }
+  if (hostname.includes('youtube')) {
+    return 'YouTube';
+  }
+  if (hostname.includes('twitch')) {
+    return 'Twitch';
+  }
+  if (hostname.includes('nebula')) {
+    return 'Nebula';
+  }
+  if (hostname.includes('vimeo')) {
+    return 'Vimeo';
+  }
+  return hostname.charAt(0).toUpperCase() + hostname.slice(1);
+}
+
+function deriveTagsFromTitle(title: string): string[] {
+  const normalized = title.toLowerCase();
+  const tags = new Set<string>();
+  if (normalized.match(/game|play|speedrun/)) {
+    tags.add('Games');
+  }
+  if (normalized.match(/learn|tutorial|guide|how to/)) {
+    tags.add('Learning');
+  }
+  if (normalized.match(/music|song|playlist/)) {
+    tags.add('Music');
+  }
+  if (normalized.match(/news|update|report/)) {
+    tags.add('News');
+  }
+  if (normalized.match(/space|science|tech|engineering/)) {
+    tags.add('Science');
+  }
+  if (normalized.match(/yoga|wellness|meditation|mindful/)) {
+    tags.add('Wellness');
+  }
+
+  if (tags.size === 0) {
+    tags.add('Favorites');
+  }
+  return Array.from(tags);
+}
+
+function generateThumbnailForTitle(title: string): string {
+  const encoded = encodeURIComponent(title.toLowerCase().replace(/\s+/g, '-'));
+  return `https://images.unsplash.com/seed/${encoded}/640x360?auto=format&fit=crop&w=1200&q=80`;
+}
+
+function generateDurationForShare() {
+  const min = 240;
+  const max = 1800;
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function generateViewCount() {
+  const min = 1200;
+  const max = 120000;
+  return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
 export function useAppStateContext() {

--- a/frontend/src/state/useAppState.ts
+++ b/frontend/src/state/useAppState.ts
@@ -14,6 +14,7 @@ export function useAppState() {
       signUp: context.signUp,
       signOut: context.signOut,
       shareVideo: context.shareVideo,
+      reactToVideo: context.reactToVideo,
       acceptInvite: context.acceptInvite,
       declineInvite: context.declineInvite,
       respondToInvite: context.respondToInvite,


### PR DESCRIPTION
## Summary
- replace the dashboard feed panel with a richer `VideoFeedPanel` that surfaces video metadata, filtering controls, and inline reactions
- extend app state feed entries to store metadata, reaction counts, and reaction toggles while enriching newly shared videos with autogenerated context
- mark the shared video feed TODO item as complete

## Testing
- pnpm lint
- pnpm vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d4e2dad038832f8d5098d8118065f8