### PR TITLE
Use self-hosted runners for workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   go-tests:
     name: Go Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
 
   frontend-tests:
     name: Frontend Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -70,7 +70,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   build:
     name: Build and publish ${{ matrix.service }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Summary
- update the CI workflow jobs to target the self-hosted runner label
- run the container build workflow on the self-hosted runner pool

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4e7caf550832f910026962a2e6748