### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- add a Dependabot configuration for GitHub Actions, Go modules, and npm packages
- schedule weekly dependency update checks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4e92de148832f80f8b7ae7f4ceb77