### PR TITLE
Add contributor setup guide and seed data instructions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,4 +24,4 @@ A living checklist of follow-up work and enhancements to guide ongoing developme
 ## Documentation
 - [x] Expand `docs/STARTUP.md` with troubleshooting tips for common setup issues.
 - [x] Document coding standards and linting/prettier configurations for both backend and frontend.
-- [ ] Create contributor guides for running migrations, seeding data, and executing the full test suite locally.
+- [x] Create contributor guides for running migrations, seeding data, and executing the full test suite locally.

--- a/backend/seeds/dev_seed.sql
+++ b/backend/seeds/dev_seed.sql
@@ -1,0 +1,36 @@
+-- dev_seed.sql
+-- Seed data to quickly populate a local VidFriends database with sample users,
+-- friend connections, and video shares. Intended for development only.
+
+BEGIN;
+
+-- Users
+INSERT INTO users (id, email, password_hash, created_at, updated_at) VALUES
+  ('11111111-1111-1111-1111-111111111111', 'alice@example.com', '$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZxYVSG3ZVSG7AV2XpFp7ZXDEh4XGa', NOW(), NOW()),
+  ('22222222-2222-2222-2222-222222222222', 'bob@example.com', '$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZxYVSG3ZVSG7AV2XpFp7ZXDEh4XGa', NOW(), NOW()),
+  ('33333333-3333-3333-3333-333333333333', 'carol@example.com', '$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZxYVSG3ZVSG7AV2XpFp7ZXDEh4XGa', NOW(), NOW())
+ON CONFLICT (email) DO NOTHING;
+
+-- Friend requests / relationships
+INSERT INTO friend_requests (id, requester_id, receiver_id, status, created_at, responded_at) VALUES
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', '11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222', 'accepted', NOW() - INTERVAL '3 days', NOW() - INTERVAL '3 days'),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '22222222-2222-2222-2222-222222222222', '33333333-3333-3333-3333-333333333333', 'pending', NOW() - INTERVAL '1 day', NULL)
+ON CONFLICT (id) DO NOTHING;
+
+-- Video shares
+INSERT INTO video_shares (id, owner_id, url, title, description, thumbnail, created_at) VALUES
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', '11111111-1111-1111-1111-111111111111',
+   'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+   'An 80s classic',
+   'Sample share for local testing. Replace with your own links as needed.',
+   'https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg',
+   NOW() - INTERVAL '2 days'),
+  ('dddddddd-dddd-dddd-dddd-dddddddddddd', '22222222-2222-2222-2222-222222222222',
+   'https://vimeo.com/148751763',
+   'Creative inspiration',
+   'Another seeded video share to exercise metadata lookups.',
+   NULL,
+   NOW() - INTERVAL '12 hours')
+ON CONFLICT (id) DO NOTHING;
+
+COMMIT;

--- a/docs/CONTRIBUTOR_GUIDE.md
+++ b/docs/CONTRIBUTOR_GUIDE.md
@@ -1,0 +1,82 @@
+# VidFriends Contributor Guide
+
+Welcome to the VidFriends project! This guide walks contributors through the day-to-day workflows for preparing a local environment, running database migrations, seeding useful development data, and executing the full automated test suite.
+
+## Prerequisites
+
+Before diving in ensure the following tooling is available:
+
+- **PostgreSQL 15+** – locally installed or via Docker Compose using the files under `deploy/`.
+- **Go 1.21+** – required for backend development and running the migration CLI.
+- **Node.js 18+ with pnpm** – used by the Vite-based frontend and its test harness.
+- **yt-dlp** – optional locally; the Docker Compose stack provides it automatically.
+
+Copy the example environment files the first time you set up the project:
+
+```bash
+cp backend/.env.example backend/.env
+cp frontend/.env.example frontend/.env
+cp deploy/.env.example deploy/.env # only if you are using docker compose
+```
+
+Update credentials and secrets inside the copied files. The backend `.env` must include `VIDFRIENDS_DATABASE_URL` that points at the database you plan to use for development/testing.
+
+## Running database migrations
+
+The backend exposes a light wrapper around our migration tooling. From the `backend/` directory run:
+
+```bash
+cd backend
+go run ./cmd/vidfriends migrate up
+```
+
+The command reads configuration from `backend/.env` (via the `VIDFRIENDS_` environment variables) and applies all pending SQL files under the directory referenced by `VIDFRIENDS_MIGRATIONS` (defaults to `backend/migrations`).
+
+Useful subcommands:
+
+- `go run ./cmd/vidfriends migrate status` – check which migrations have run.
+- `go run ./cmd/vidfriends migrate down 1` – roll back the most recent migration. Use carefully; this impacts your database state.
+
+If you are using Docker Compose, make sure the stack is up so the backend CLI can reach the Postgres container:
+
+```bash
+cd deploy
+docker compose up db -d
+```
+
+## Seeding development data
+
+Populate a local database with sample content using the seed script in `backend/seeds/dev_seed.sql`. This script inserts a few demo users, establishes friend relationships, and creates representative video shares so the UI has data out of the box.
+
+Run the seed file with `psql`, substituting your connection URL:
+
+```bash
+psql "$VIDFRIENDS_DATABASE_URL" -f backend/seeds/dev_seed.sql
+```
+
+The inserted users share the password `password` (hashed with bcrypt). Feel free to customize or extend the script with your own data; rerunning it is safe thanks to the `ON CONFLICT` guards.
+
+## Running the automated tests
+
+Run all backend Go tests from the repository root:
+
+```bash
+cd backend
+go test ./...
+```
+
+For the frontend, install dependencies (if you have not already) and execute the Vite/Jest test runner:
+
+```bash
+cd frontend
+pnpm install
+pnpm test
+```
+
+Optionally lint the codebases before submitting changes:
+
+```bash
+./scripts/lint.sh
+```
+
+Running both backend and frontend test suites before opening a pull request ensures CI passes cleanly and that your environment mirrors the continuous integration pipeline.


### PR DESCRIPTION
## Summary
- add a contributor guide that documents local prerequisites, migrations, seeding, and testing workflows
- provide a reusable SQL seed script so developers can populate sample data for the app
- check off the documentation TODO entry for the new guide

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4ecb30fe4832f99d1443a0dc476d9