### PR TITLE
chore: refresh project todo backlog

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,27 +1,50 @@
-# VidFriends TODO List
+# VidFriends TODO Backlog
 
-A living checklist of follow-up work and enhancements to guide ongoing development.
+A curated list of follow-up work to bring the platform from the current prototype
+state to the feature set described in the documentation.
 
 ## Infrastructure & Tooling
-- [x] Review and document the Docker Compose services in `deploy/` to clarify how the backend, frontend, and database interact.
-- [x] Automate CI workflows to run Go tests, frontend unit tests, and linting on every pull request.
-- [x] Set up container build automation that publishes multi-architecture images (x86_64 and arm64).
+- [ ] Add a Makefile or task runner that wraps common workflows (tests, lint,
+      database migrations) for both services.
+- [ ] Configure CI to run `go test ./...`, frontend unit tests, and linting so
+      regressions are caught automatically.
+- [ ] Provide container images or Docker Compose overrides that bundle the
+      `yt-dlp` binary and seed data for local onboarding.
 
 ## Backend
-- [x] Flesh out the Go project structure under `backend/` with handlers, data models, and migrations.
-- [x] Implement authentication endpoints, including session management and token refresh.
-- [x] Add friend management APIs (invite, accept, block) with appropriate database migrations.
-- [x] Integrate yt-dlp metadata lookups for shared video links and cache results.
-- [x] Write comprehensive Go tests for handlers, repositories, and domain logic.
+- [ ] Implement PostgreSQL-backed repositories for users, friend requests, and
+      video shares, then wire them into the HTTP handlers.
+- [ ] Replace the in-memory session manager with a persistence-aware solution or
+      make it pluggable so access/refresh tokens survive process restarts.
+- [ ] Flesh out the migration CLI (`go run ./cmd/vidfriends migrate ...`) so it
+      actually runs migrations using the configured database URL.
+- [ ] Implement the `/api/v1/videos/feed` endpoint backed by repository queries
+      that respect a viewer's friendships.
+- [ ] Add password reset endpoints to match the frontend's expectations or
+      adjust the client to avoid broken calls.
+- [ ] Expand handler and repository test coverage with database integration
+      tests (using a test container or transactional rollback strategy).
+- [ ] Introduce structured logging and request-scoped context values so errors
+      surface actionable metadata.
 
 ## Frontend
-- [x] Scaffold the React + TypeScript application under `frontend/` with routing and global state management.
-- [x] Implement authentication flows (signup, login, password reset) against the backend APIs.
- - [x] Build friend list management UI with optimistic updates and error handling.
-- [x] Design the shared video feed with metadata display, reactions, and filtering.
-- [x] Add frontend unit and integration tests covering critical user journeys.
+- [ ] Replace the hard-coded mock data in `AppStateProvider` with real API calls
+      for friends, feed entries, and invitations. Provide a mock layer that can
+      be toggled for offline development.
+- [ ] Align friend invitation mutation URLs with the backend (`/api/v1/friends/respond`)
+      and add optimistic update rollbacks when the API rejects changes.
+- [ ] Persist and refresh authentication tokens by calling the backend
+      `/api/v1/auth/refresh` endpoint before the access token expires.
+- [ ] Implement a share-video form that calls the backend and handles metadata
+      lookup latency states.
+- [ ] Add Vitest/RTL coverage for the dashboard widgets, auth forms, and state
+      reducer logic.
 
 ## Documentation
-- [x] Expand `docs/STARTUP.md` with troubleshooting tips for common setup issues.
-- [x] Document coding standards and linting/prettier configurations for both backend and frontend.
-- [x] Create contributor guides for running migrations, seeding data, and executing the full test suite locally.
+- [ ] Update the README and startup guides to reflect the current implementation
+      status (e.g. mock data, incomplete endpoints) so new contributors know what
+      to expect.
+- [ ] Add an API reference that documents available endpoints, request/response
+      bodies, and authentication requirements.
+- [ ] Document environment variable defaults for both services in a single
+      location to reduce duplication between guides.


### PR DESCRIPTION
## Summary
- replace the completed-only TODO checklist with a backlog that reflects the current implementation gaps
- capture backend, frontend, documentation, and tooling follow-ups needed to align the code with the documented goals

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d4ee145c5c832fa0a3e3ab8a7bd9cd