### PR TITLE
Add Makefile wrapper for backend and frontend workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+SHELL := /bin/bash
+
+BACKEND_DIR := backend
+FRONTEND_DIR := frontend
+PNPM := pnpm
+
+.PHONY: help test lint backend-test backend-lint backend-migrate-up backend-migrate-down backend-migrate-status frontend-install frontend-test frontend-lint frontend-build
+
+help: ## Show available make targets
+	@awk 'BEGIN {FS = ":.*## "} /^[a-zA-Z0-9_-]+:.*## / {printf "\033[36m%-24s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+test: backend-test frontend-test ## Run backend and frontend test suites
+
+lint: backend-lint frontend-lint ## Run linting for both services
+
+backend-test: ## Run Go unit tests for the backend service
+	cd $(BACKEND_DIR) && go test ./...
+
+backend-lint: ## Run Go linters for the backend service
+	@if command -v golangci-lint >/dev/null 2>&1; then \
+		cd $(BACKEND_DIR) && golangci-lint run; \
+	else \
+		echo "golangci-lint not installed; skipping backend lint."; \
+	fi
+
+backend-migrate-up: ## Apply database migrations (up) using the backend CLI
+	cd $(BACKEND_DIR) && go run ./cmd/vidfriends migrate up
+
+backend-migrate-down: ## Roll back the most recent migration (down) using the backend CLI
+	cd $(BACKEND_DIR) && go run ./cmd/vidfriends migrate down
+
+backend-migrate-status: ## Show the status of database migrations using the backend CLI
+	cd $(BACKEND_DIR) && go run ./cmd/vidfriends migrate status
+
+frontend-install: ## Install frontend dependencies with pnpm
+	$(PNPM) --dir $(FRONTEND_DIR) install
+
+frontend-test: ## Run frontend unit tests with Vitest
+	$(PNPM) --dir $(FRONTEND_DIR) test
+
+frontend-lint: ## Run frontend linting with ESLint
+	$(PNPM) --dir $(FRONTEND_DIR) lint
+
+frontend-build: ## Build the production frontend bundle with Vite
+	$(PNPM) --dir $(FRONTEND_DIR) build

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@ A curated list of follow-up work to bring the platform from the current prototyp
 state to the feature set described in the documentation.
 
 ## Infrastructure & Tooling
-- [ ] Add a Makefile or task runner that wraps common workflows (tests, lint,
+- [x] Add a Makefile or task runner that wraps common workflows (tests, lint,
       database migrations) for both services.
 - [ ] Configure CI to run `go test ./...`, frontend unit tests, and linting so
       regressions are caught automatically.


### PR DESCRIPTION
## Summary
- add a repository-level Makefile that wraps backend tests, linting, migrations, and frontend pnpm scripts
- mark the infrastructure TODO entry for the Makefile/task runner as complete

## Testing
- make help

------
https://chatgpt.com/codex/tasks/task_e_68d4f05a359c832f8c4bb37d45e12531