### PR TITLE
Document yt-dlp video download workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # VidFriends
 
 VidFriends is a full-stack video sharing platform with a Go backend, PostgreSQL persistence, and a React + TypeScript frontend. The
-backend exposes REST endpoints for authentication, friendship management, and sharing video links with yt-dlp metadata lookups,
+backend exposes REST endpoints for authentication, friendship management, and sharing video links with yt-dlp metadata lookups and downloads so shared videos can be stored locally for playback,
 while the frontend delivers a responsive, dark-themed single-page app for managing your feed.
 
 ## Getting started

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -71,7 +71,8 @@ relationships and exposed ports.
 ### `yt-dlp`
 - **Image**: Lightweight container that only ships the `yt-dlp` binary.
 - **Purpose**: Supplies the backend with a pinned version of `yt-dlp` for video
-  metadata lookups. The binary is shared over a volume mounted at
+  metadata lookups and downloading shared videos so they can be persisted for
+  playback. The binary is shared over a volume mounted at
   `/usr/local/bin/yt-dlp` in the backend container.
 - **Customization**: You can disable this service if you have `yt-dlp` installed
   on the host by updating `YT_DLP_PATH`.

--- a/docs/CONTRIBUTOR_GUIDE.md
+++ b/docs/CONTRIBUTOR_GUIDE.md
@@ -9,7 +9,7 @@ Before diving in ensure the following tooling is available:
 - **PostgreSQL 15+** – locally installed or via Docker Compose using the files under `deploy/`.
 - **Go 1.21+** – required for backend development and running the migration CLI.
 - **Node.js 18+ with pnpm** – used by the Vite-based frontend and its test harness.
-- **yt-dlp** – optional locally; the Docker Compose stack provides it automatically.
+- **yt-dlp** – optional locally; the Docker Compose stack provides it automatically for metadata and video downloads.
 
 Copy the example environment files the first time you set up the project:
 

--- a/docs/FIRST_STEPS.md
+++ b/docs/FIRST_STEPS.md
@@ -27,7 +27,7 @@ the sections sequentially and tick each box as you finish the activity.
       `frontend/.env.local`, and `deploy/.env`) and replace placeholder values
       with secrets and connection strings that match your local setup.
 - [ ] Install any optional tooling called out by the script output (e.g.
-      `golangci-lint`, `yt-dlp`, or Docker) so future steps run smoothly.
+      `golangci-lint`, `yt-dlp`, or Docker) so future steps run smoothly and shared videos can be downloaded and stored for playback.
 
 ## 3. Run the stack locally
 

--- a/docs/STARTUP.md
+++ b/docs/STARTUP.md
@@ -21,7 +21,7 @@ Install the following software before you begin:
 | [Node.js](https://nodejs.org/en/download/) | 18 LTS | Runs the React development server and tooling. |
 | [pnpm](https://pnpm.io/installation) or [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) | latest | Installs frontend dependencies. |
 | [PostgreSQL](https://www.postgresql.org/download/) | 14+ | Local development database. |
-| [yt-dlp](https://github.com/yt-dlp/yt-dlp#installation) | latest | CLI utility used by the backend for video metadata lookups. |
+| [yt-dlp](https://github.com/yt-dlp/yt-dlp#installation) | latest | CLI utility used by the backend for video metadata lookups and downloading shared videos for storage. |
 
 Optional but recommended:
 
@@ -147,7 +147,7 @@ By default the development server runs on `http://localhost:5173`. It proxies AP
 
 1. Visit `http://localhost:5173` and sign up for a new account.
 2. Add a friend using their username or email.
-3. Share a video link to confirm yt-dlp metadata retrieval.
+3. Share a video link to confirm yt-dlp metadata retrieval and download-to-storage workflow.
 4. Check the "Feed" tab to ensure shared videos appear.
 
 The backend logs should show API traffic and share fan-out operations, while the database should record new users, sessions, and shares.
@@ -224,7 +224,7 @@ files for typos or missing values, so start there before digging into deeper deb
 | API fails to start with `pq: password authentication failed` | Incorrect database credentials | Double-check `DATABASE_URL` and PostgreSQL role configuration. |
 | Go API exits with `dial tcp 127.0.0.1:5432: connect: connection refused` | PostgreSQL server is not running or listening on a different port | Start PostgreSQL (`brew services start postgresql` / `systemctl start postgresql`) and confirm the port matches `DATABASE_URL`. |
 | `go run ./cmd/vidfriends serve` reloads repeatedly in Docker | The source tree is mounted with root-owned files, causing `air` to fail watching | Run `sudo chown -R $(id -u):$(id -g) .` inside the repo or adjust the bind mount user in `docker-compose.yml`. |
-| `yt-dlp` errors when fetching metadata | Missing binary or rate-limiting | Install `yt-dlp` locally, or set `YT_DLP_PATH` to a bundled binary. Wait/retry if the provider is rate-limiting. |
+| `yt-dlp` errors when fetching metadata or downloading files | Missing binary, insufficient disk space, or rate-limiting | Install `yt-dlp` locally, ensure the storage volume has capacity, or set `YT_DLP_PATH` to a bundled binary. Wait/retry if the provider is rate-limiting. |
 | `pnpm install` fails with "unsupported engine" | Your Node.js runtime is older than the minimum version | Upgrade Node.js to the current LTS release (18+) and re-run `pnpm install`. |
 | CORS errors in the browser console | Frontend origin not in backend `CORS_ALLOWED_ORIGINS` | Update the backend `.env` to include the frontend dev origin. |
 | Session cookie missing in requests | Browser blocked third-party cookies or secure flag mismatch | Use the same domain/port in development and ensure `SESSION_SECURE=false` for HTTP. |


### PR DESCRIPTION
## Summary
- note in the top-level README that yt-dlp now handles metadata lookups and downloading shared videos for local playback
- update contributor and startup guides to explain the download/storage role and troubleshooting considerations
- clarify the deploy documentation so the yt-dlp helper container is described as supporting video downloads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4f1c928ec832f987e017317ba82eb