### PR TITLE
Configure CI workflows for tests and linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,19 @@ name: CI
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
   push:
-    branches: [ main ]
+    branches: [main]
+
+env:
+  GO_VERSION_FILE: backend/go.mod
+  FALLBACK_GO_VERSION: '1.21'
+  NODE_VERSION: '18'
 
 jobs:
   go-tests:
     name: Go Tests
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -17,8 +22,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: backend/go.mod
-          fallback-go-version: '1.21'
+          go-version-file: ${{ env.GO_VERSION_FILE }}
+          fallback-go-version: ${{ env.FALLBACK_GO_VERSION }}
 
       - name: Run Go unit tests
         working-directory: backend
@@ -31,7 +36,7 @@ jobs:
 
   frontend-tests:
     name: Frontend Unit Tests
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -39,38 +44,28 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '18'
-          cache: 'npm'
-          cache-dependency-path: |
-            frontend/package-lock.json
-            frontend/pnpm-lock.yaml
-            frontend/yarn.lock
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: frontend/pnpm-lock.yaml
 
-      - name: Install dependencies and run tests
+      - name: Install dependencies
         working-directory: frontend
         run: |
-          if [ -f package.json ]; then
-            if [ -f pnpm-lock.yaml ]; then
-              corepack enable pnpm
-              pnpm install --frozen-lockfile
-              pnpm test -- --watch=false
-            elif [ -f package-lock.json ]; then
-              npm ci
-              npm test -- --watch=false
-            elif [ -f yarn.lock ]; then
-              corepack enable
-              yarn install --immutable
-              yarn test --watch=false
-            else
-              npm install
-              npm test -- --watch=false
-            fi
-          else
+          if [ ! -f package.json ]; then
             echo "No frontend/package.json found. Skipping frontend tests."
+            exit 0
+          fi
+          corepack enable pnpm
+          pnpm install --frozen-lockfile
+
+      - name: Run unit tests
+        if: hashFiles('frontend/package.json') != ''
+        working-directory: frontend
+        run: pnpm vitest run
 
   lint:
     name: Lint
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -78,12 +73,18 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '18'
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.21'
+          go-version-file: ${{ env.GO_VERSION_FILE }}
+          fallback-go-version: ${{ env.FALLBACK_GO_VERSION }}
+
+      - name: Prepare pnpm
+        run: corepack enable pnpm
 
       - name: Run lint checks
         run: bash scripts/lint.sh

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@ state to the feature set described in the documentation.
 ## Infrastructure & Tooling
 - [x] Add a Makefile or task runner that wraps common workflows (tests, lint,
       database migrations) for both services.
-- [ ] Configure CI to run `go test ./...`, frontend unit tests, and linting so
+- [x] Configure CI to run `go test ./...`, frontend unit tests, and linting so
       regressions are caught automatically.
 - [ ] Provide container images or Docker Compose overrides that bundle the
       `yt-dlp` binary and seed data for local onboarding.

--- a/backend/internal/handlers/routes.go
+++ b/backend/internal/handlers/routes.go
@@ -7,7 +7,7 @@ func RegisterRoutes(mux *http.ServeMux, deps Dependencies) {
 	health := HealthHandler{}
 	auth := AuthHandler{Users: deps.Users, Sessions: deps.Sessions}
 	friends := FriendHandler{Friends: deps.Friends}
-        videos := VideoHandler{Videos: deps.Videos, Metadata: deps.VideoMetadata}
+	videos := VideoHandler{Videos: deps.Videos, Metadata: deps.VideoMetadata}
 
 	mux.HandleFunc("/healthz", health.Handle)
 	mux.HandleFunc("/api/v1/auth/login", auth.Login)
@@ -22,9 +22,9 @@ func RegisterRoutes(mux *http.ServeMux, deps Dependencies) {
 
 // Dependencies aggregates collaborators required by HTTP handlers.
 type Dependencies struct {
-        Users    UserStore
-        Sessions SessionManager
-        Friends  FriendStore
-        Videos   VideoStore
-        VideoMetadata VideoMetadataProvider
+	Users         UserStore
+	Sessions      SessionManager
+	Friends       FriendStore
+	Videos        VideoStore
+	VideoMetadata VideoMetadataProvider
 }


### PR DESCRIPTION
## Summary
- switch CI workflow to GitHub-hosted runners with shared Go and Node version settings
- configure frontend job to install dependencies with pnpm caching and run vitest in non-watch mode
- prepare pnpm for lint checks and keep the TODO list in sync with the new workflow

## Testing
- bash scripts/lint.sh
- go test ./...
- pnpm vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d4f19c0a6c832fbe330d5cb7652528