### PR TITLE
Add MinIO storage container to docker compose

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -11,3 +11,10 @@ SESSION_SECRET=replace-with-secure-random-string
 
 # Directory containing SQL migrations.
 VIDFRIENDS_MIGRATIONS=migrations
+
+# S3-compatible storage configuration used for hosting processed videos.
+VIDFRIENDS_S3_ENDPOINT=http://localhost:9000
+VIDFRIENDS_S3_BUCKET=vidfriends
+VIDFRIENDS_S3_REGION=us-east-1
+VIDFRIENDS_S3_PUBLIC_BASE_URL=http://localhost:9000/vidfriends
+

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -17,3 +17,15 @@ YT_DLP_PATH=/usr/local/bin/yt-dlp
 # Hostnames/ports exposed by the services.
 BACKEND_PORT=8080
 FRONTEND_PORT=5173
+
+# MinIO (S3-compatible) configuration for video storage.
+MINIO_ROOT_USER=vidfriends
+MINIO_ROOT_PASSWORD=vidfriends-secret
+MINIO_API_PORT=9000
+MINIO_CONSOLE_PORT=9001
+
+# S3 bucket settings consumed by the backend.
+VIDFRIENDS_S3_BUCKET=vidfriends
+VIDFRIENDS_S3_REGION=us-east-1
+VIDFRIENDS_S3_PUBLIC_BASE_URL=http://localhost:9000/vidfriends
+

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,111 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  minio:
+    image: minio/minio:RELEASE.2024-01-13T07-53-03Z
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+    volumes:
+      - minio-data:/data
+    ports:
+      - "${MINIO_API_PORT:-9000}:9000"
+      - "${MINIO_CONSOLE_PORT:-9001}:9001"
+
+  createbuckets:
+    image: minio/mc:RELEASE.2024-01-11T07-46-16Z
+    depends_on:
+      minio:
+        condition: service_started
+    entrypoint: >-
+      /bin/sh -c "
+      until mc alias set minio http://minio:9000 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD}; do
+        sleep 2
+      done
+      mc mb --ignore-existing minio/${VIDFRIENDS_S3_BUCKET} &&
+      mc anonymous set download minio/${VIDFRIENDS_S3_BUCKET}
+      "
+    restart: "no"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+      VIDFRIENDS_S3_BUCKET: ${VIDFRIENDS_S3_BUCKET}
+
+  yt-dlp:
+    image: ghcr.io/yt-dlp/yt-dlp:2023.11.14
+    entrypoint: >-
+      /bin/sh -c "
+      cp /usr/local/bin/yt-dlp /shared/yt-dlp && chmod +x /shared/yt-dlp &&
+      tail -f /dev/null
+      "
+    volumes:
+      - yt-dlp-bin:/shared
+
+  backend:
+    image: golang:1.22
+    depends_on:
+      db:
+        condition: service_healthy
+      createbuckets:
+        condition: service_completed_successfully
+    working_dir: /app
+    command: sh -c "go run ./cmd/vidfriends serve"
+    env_file:
+      - ../backend/.env
+    environment:
+      VIDFRIENDS_PORT: ${BACKEND_PORT}
+      VIDFRIENDS_DATABASE_URL: ${DATABASE_URL}
+      SESSION_SECRET: ${SESSION_SECRET}
+      VIDFRIENDS_YTDLP_PATH: ${YT_DLP_PATH}
+      VIDFRIENDS_S3_ENDPOINT: http://minio:9000
+      VIDFRIENDS_S3_BUCKET: ${VIDFRIENDS_S3_BUCKET}
+      VIDFRIENDS_S3_REGION: ${VIDFRIENDS_S3_REGION}
+      VIDFRIENDS_S3_PUBLIC_BASE_URL: ${VIDFRIENDS_S3_PUBLIC_BASE_URL}
+      AWS_ACCESS_KEY_ID: ${MINIO_ROOT_USER}
+      AWS_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
+      AWS_REGION: ${VIDFRIENDS_S3_REGION}
+    volumes:
+      - ../backend:/app
+      - yt-dlp-bin:/usr/local/bin
+    ports:
+      - "${BACKEND_PORT:-8080}:8080"
+
+  frontend:
+    image: node:20
+    depends_on:
+      backend:
+        condition: service_started
+    working_dir: /app
+    command: sh -c "corepack enable && pnpm install && pnpm dev --host 0.0.0.0 --port 5173"
+    env_file:
+      - ../frontend/.env
+    environment:
+      VITE_API_BASE_URL: http://backend:8080
+    volumes:
+      - ../frontend:/app
+    ports:
+      - "${FRONTEND_PORT:-5173}:5173"
+
+volumes:
+  db-data:
+  minio-data:
+  yt-dlp-bin:

--- a/docs/STARTUP.md
+++ b/docs/STARTUP.md
@@ -163,18 +163,22 @@ The repository ships with `deploy/docker-compose.yml` to orchestrate the service
 ```bash
 cd deploy
 cp .env.example .env  # if you haven't already
-# Edit .env to set secrets like DATABASE_URL, SESSION_SECRET, etc.
-docker compose up --build
+# Edit .env to set secrets like DATABASE_URL, SESSION_SECRET, and MinIO credentials.
+docker compose up --build --remove-orphans
 ```
 
 This command launches the following containers:
 
 - `db` – PostgreSQL with initialized databases and volumes for persistence.
-- `backend` – Go API service with hot-reload support (via `air`) mounting your source tree.
+- `backend` – Go API service running `go run ./cmd/vidfriends serve` with the repo mounted as a volume.
 - `frontend` – React dev server served via Vite.
-- `yt-dlp` – optional helper image that caches the `yt-dlp` binary.
+- `minio` – S3-compatible object storage that holds processed video assets.
+- `yt-dlp` – helper image that copies the `yt-dlp` binary onto a shared volume.
+- `createbuckets` – one-time MinIO client job that provisions the public bucket defined in `.env`.
 
-Wait until the logs show the API listening and migrations completing. The frontend is accessible at `http://localhost:5173` and the API at `http://localhost:8080`.
+Wait until the logs show the API listening, the bucket provisioning job exiting successfully, and PostgreSQL reporting healthy.
+The frontend is accessible at `http://localhost:5173`, the API at `http://localhost:8080`, and the object storage browser at
+`http://localhost:9001`.
 
 ### 5.2 Running commands inside containers
 


### PR DESCRIPTION
## Summary
- add a docker compose stack with MinIO, PostgreSQL, backend, frontend, and helper services for local development
- document MinIO/S3 configuration in the Compose README and startup guide, including public bucket provisioning
- surface new S3-related environment variables in the backend and deploy environment examples

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4f402b3d8832f9308ea7531ba4de9