### PR TITLE
Replace placeholder Dockerfiles with runnable backend/frontend images

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@ state to the feature set described in the documentation.
       regressions are caught automatically.
 - [x] Provide container images or Docker Compose overrides that bundle the
       `yt-dlp` binary and seed data for local onboarding.
-- [ ] Replace the placeholder backend and frontend Dockerfiles with builds that
+- [x] Replace the placeholder backend and frontend Dockerfiles with builds that
       produce runnable images for the real services.
 - [ ] Ensure local configuration templates match the documented repo layout
       (e.g. add or document the missing `configs/` directory references).

--- a/deploy/docker/backend.Dockerfile
+++ b/deploy/docker/backend.Dockerfile
@@ -1,8 +1,28 @@
 # syntax=docker/dockerfile:1.6
-FROM golang:1.22-alpine AS runtime
-LABEL org.opencontainers.image.source="https://github.com/${GITHUB_REPOSITORY}"
-LABEL org.opencontainers.image.description="VidFriends backend service container image (placeholder)."
+FROM golang:1.23-alpine AS builder
+
+WORKDIR /src
+RUN apk add --no-cache build-base
+
+COPY backend/go.mod backend/go.sum ./
+RUN go mod download
+
+COPY backend/ ./
+RUN CGO_ENABLED=0 GOOS=linux go build -o /out/vidfriends ./cmd/vidfriends
+
+FROM alpine:3.20 AS runtime
+RUN addgroup -S vidfriends && adduser -S -G vidfriends vidfriends
 WORKDIR /app
-COPY backend/README.md /app/README.md
-ENV VIDFRIENDS_SERVICE=backend
-CMD ["/bin/sh", "-c", "echo VidFriends backend image placeholder"]
+
+COPY --from=builder /out/vidfriends /usr/local/bin/vidfriends
+COPY backend/migrations ./migrations
+COPY backend/seeds ./seeds
+
+RUN chown -R vidfriends:vidfriends /app /usr/local/bin/vidfriends
+USER vidfriends
+
+ENV VIDFRIENDS_MIGRATIONS=/app/migrations
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/vidfriends"]
+CMD ["serve"]

--- a/deploy/docker/frontend.Dockerfile
+++ b/deploy/docker/frontend.Dockerfile
@@ -1,8 +1,24 @@
 # syntax=docker/dockerfile:1.6
-FROM node:20-alpine
-LABEL org.opencontainers.image.source="https://github.com/${GITHUB_REPOSITORY}"
-LABEL org.opencontainers.image.description="VidFriends frontend application container image (placeholder)."
+FROM node:20-alpine AS builder
+
 WORKDIR /app
-COPY frontend/README.md /app/README.md
-ENV VIDFRIENDS_SERVICE=frontend
-CMD ["/bin/sh", "-c", "echo VidFriends frontend image placeholder"]
+ENV PNPM_HOME=/pnpm
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+COPY frontend/pnpm-lock.yaml frontend/package.json ./
+RUN pnpm install --frozen-lockfile
+
+COPY frontend/ ./ \
+    --exclude=frontend/dist \
+    --exclude=frontend/node_modules \
+    --exclude=frontend/.env* \
+    --exclude=frontend/.vite
+
+RUN pnpm build
+
+FROM nginx:1.27-alpine AS runtime
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY deploy/docker/frontend.nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/deploy/docker/frontend.nginx.conf
+++ b/deploy/docker/frontend.nginx.conf
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+
+    include /etc/nginx/mime.types;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- replace the backend Dockerfile with a multi-stage build that compiles the Go API and packages migrations/seeds in a minimal runtime image
- rebuild the frontend Dockerfile so pnpm produces a production Vite bundle that Nginx serves with an SPA-friendly config
- add the Nginx site config and mark the TODO item complete

## Testing
- go test ./...
- pnpm install
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d4f894dfe8832fb40033c7f2943d11