### PR TITLE
Implement migration CLI

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,7 +20,7 @@ state to the feature set described in the documentation.
       video shares, then wire them into the HTTP handlers.
 - [x] Replace the in-memory session manager with a persistence-aware solution or
       make it pluggable so access/refresh tokens survive process restarts.
-- [ ] Flesh out the migration CLI (`go run ./cmd/vidfriends migrate ...`) so it
+- [x] Flesh out the migration CLI (`go run ./cmd/vidfriends migrate ...`) so it
       actually runs migrations using the configured database URL.
 - [ ] Implement the `/api/v1/videos/feed` endpoint backed by repository queries
       that respect a viewer's friendships.

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"sort"
 	"syscall"
 	"time"
 
@@ -96,12 +98,132 @@ func serve(ctx context.Context) error {
 }
 
 func runMigrations(ctx context.Context, args []string) error {
-	_ = ctx
 	cfg, err := config.Load()
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("running migrations in %s with args %v\n", cfg.MigrationDir, args)
-	return nil
+	command := "up"
+	if len(args) > 0 {
+		command = args[0]
+	}
+
+	migrationDir := cfg.MigrationDir
+	if !filepath.IsAbs(migrationDir) {
+		wd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("determine working directory: %w", err)
+		}
+		migrationDir = filepath.Join(wd, migrationDir)
+	}
+
+	entries, err := os.ReadDir(migrationDir)
+	if err != nil {
+		return fmt.Errorf("read migrations directory: %w", err)
+	}
+
+	var migrations []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if filepath.Ext(entry.Name()) != ".sql" {
+			continue
+		}
+		migrations = append(migrations, entry.Name())
+	}
+
+	sort.Strings(migrations)
+
+	pool, err := db.Connect(ctx, cfg.DatabaseURL)
+	if err != nil {
+		return err
+	}
+	defer pool.Close()
+
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire connection: %w", err)
+	}
+	defer conn.Release()
+
+	if _, err := conn.Exec(ctx, `CREATE TABLE IF NOT EXISTS schema_migrations (
+                version TEXT PRIMARY KEY,
+                applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )`); err != nil {
+		return fmt.Errorf("ensure schema_migrations table: %w", err)
+	}
+
+	rows, err := conn.Query(ctx, `SELECT version FROM schema_migrations`)
+	if err != nil {
+		return fmt.Errorf("fetch applied migrations: %w", err)
+	}
+	defer rows.Close()
+
+	applied := make(map[string]struct{})
+	for rows.Next() {
+		var version string
+		if err := rows.Scan(&version); err != nil {
+			return fmt.Errorf("scan applied migration: %w", err)
+		}
+		applied[version] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate applied migrations: %w", err)
+	}
+
+	switch command {
+	case "status":
+		for _, name := range migrations {
+			if _, ok := applied[name]; ok {
+				fmt.Printf("[x] %s\n", name)
+			} else {
+				fmt.Printf("[ ] %s\n", name)
+			}
+		}
+		return nil
+	case "up", "":
+		if len(migrations) == 0 {
+			fmt.Println("no migrations to apply")
+			return nil
+		}
+
+		for _, name := range migrations {
+			if _, ok := applied[name]; ok {
+				continue
+			}
+
+			path := filepath.Join(migrationDir, name)
+			contents, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("read migration %s: %w", name, err)
+			}
+
+			tx, err := conn.Begin(ctx)
+			if err != nil {
+				return fmt.Errorf("begin migration transaction for %s: %w", name, err)
+			}
+
+			if _, err := tx.Exec(ctx, string(contents)); err != nil {
+				_ = tx.Rollback(ctx)
+				return fmt.Errorf("apply migration %s: %w", name, err)
+			}
+
+			if _, err := tx.Exec(ctx, `INSERT INTO schema_migrations (version) VALUES ($1)`, name); err != nil {
+				_ = tx.Rollback(ctx)
+				return fmt.Errorf("record migration %s: %w", name, err)
+			}
+
+			if err := tx.Commit(ctx); err != nil {
+				return fmt.Errorf("commit migration %s: %w", name, err)
+			}
+
+			fmt.Printf("applied migration %s\n", name)
+		}
+		return nil
+	case "down":
+		return errors.New("down migrations are not supported yet")
+	default:
+		return fmt.Errorf("unknown migrate command %q", command)
+	}
 }


### PR DESCRIPTION
## Summary
- add a functional migration runner to the backend CLI that connects to the configured database, applies pending SQL files, and reports status
- update the TODO backlog to reflect the completed migration CLI work

## Testing
- go test ./... *(hangs indefinitely in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d50d6e1d00832face20b1447478627