### PR TITLE
Implement video feed endpoint backed by friendships

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -22,7 +22,7 @@ state to the feature set described in the documentation.
       make it pluggable so access/refresh tokens survive process restarts.
 - [x] Flesh out the migration CLI (`go run ./cmd/vidfriends migrate ...`) so it
       actually runs migrations using the configured database URL.
-- [ ] Implement the `/api/v1/videos/feed` endpoint backed by repository queries
+- [x] Implement the `/api/v1/videos/feed` endpoint backed by repository queries
       that respect a viewer's friendships.
 - [ ] Instantiate concrete service dependencies in the HTTP server so handlers
       no longer return "service unavailable" for every request.


### PR DESCRIPTION
## Summary
- implement the video feed HTTP handler with query parameter validation and error handling
- extend the Postgres repository to query shares from the viewer and accepted friends
- expand handler unit tests and mark the feed TODO item as complete

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d5168a8cd8832fb1a576294b98d1f0