### PR TITLE
Add request scoped structured logging to backend handlers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -30,7 +30,7 @@ state to the feature set described in the documentation.
       adjust the client to avoid broken calls.
 - [x] Expand handler and repository test coverage with database integration
       tests (using a test container or transactional rollback strategy).
-- [ ] Introduce structured logging and request-scoped context values so errors
+- [x] Introduce structured logging and request-scoped context values so errors
       surface actionable metadata.
 - [ ] Update the video ingestion pipeline to download and persist assets when
       requested instead of invoking `yt-dlp` with `--skip-download`.

--- a/backend/internal/logging/context.go
+++ b/backend/internal/logging/context.go
@@ -1,0 +1,52 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+)
+
+// ctxKey is an unexported type for context keys defined in this package.
+type ctxKey string
+
+const (
+	loggerKey    ctxKey = "logger"
+	requestIDKey ctxKey = "requestID"
+)
+
+// WithLogger stores the provided logger on the context.
+func WithLogger(ctx context.Context, logger *slog.Logger) context.Context {
+	if ctx == nil || logger == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, loggerKey, logger)
+}
+
+// FromContext returns the request-scoped logger or falls back to slog.Default().
+func FromContext(ctx context.Context) *slog.Logger {
+	if ctx == nil {
+		return slog.Default()
+	}
+	if logger, ok := ctx.Value(loggerKey).(*slog.Logger); ok && logger != nil {
+		return logger
+	}
+	return slog.Default()
+}
+
+// WithRequestID stores a request identifier on the context.
+func WithRequestID(ctx context.Context, requestID string) context.Context {
+	if ctx == nil || requestID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, requestIDKey, requestID)
+}
+
+// RequestIDFromContext retrieves a previously stored request identifier.
+func RequestIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if requestID, ok := ctx.Value(requestIDKey).(string); ok {
+		return requestID
+	}
+	return ""
+}

--- a/backend/internal/middleware/request_logger.go
+++ b/backend/internal/middleware/request_logger.go
@@ -1,0 +1,63 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/vidfriends/backend/internal/logging"
+)
+
+type responseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (rw *responseWriter) WriteHeader(status int) {
+	rw.status = status
+	rw.ResponseWriter.WriteHeader(status)
+}
+
+func (rw *responseWriter) Status() int {
+	if rw.status == 0 {
+		return http.StatusOK
+	}
+	return rw.status
+}
+
+// RequestLogger decorates requests with structured logging metadata.
+func RequestLogger(base *slog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			requestID := uuid.NewString()
+
+			reqLogger := base.With(
+				slog.String("request_id", requestID),
+				slog.String("method", r.Method),
+				slog.String("path", r.URL.Path),
+				slog.String("remote_addr", r.RemoteAddr),
+			)
+
+			ctx := logging.WithLogger(r.Context(), reqLogger)
+			ctx = logging.WithRequestID(ctx, requestID)
+
+			wrapped := &responseWriter{ResponseWriter: w}
+
+			defer func() {
+				if rec := recover(); rec != nil {
+					reqLogger.Error("panic recovered", "panic", rec)
+					http.Error(wrapped, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				}
+				reqLogger.Info("request completed",
+					slog.Int("status", wrapped.Status()),
+					slog.Duration("duration", time.Since(start)),
+				)
+			}()
+
+			next.ServeHTTP(wrapped, r.WithContext(ctx))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add logging context helpers and a request logger middleware that assigns per-request IDs
- wire the middleware into the HTTP server bootstrap and make JSON responses log contextual errors
- update backend handlers to use contextual loggers and mark the structured logging TODO complete

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d5220bc6d8832f85b8782f97a4dbad