### PR TITLE
Load object storage configuration from env

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -34,7 +34,7 @@ state to the feature set described in the documentation.
       surface actionable metadata.
 - [x] Update the video ingestion pipeline to download and persist assets when
       requested instead of invoking `yt-dlp` with `--skip-download`.
-- [ ] Extend configuration loading to honor documented object storage (S3/MinIO)
+- [x] Extend configuration loading to honor documented object storage (S3/MinIO)
       environment variables.
 
 ## Frontend

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -15,6 +15,16 @@ type Config struct {
 	YTDLPPath        string
 	YTDLPTimeout     time.Duration
 	MetadataCacheTTL time.Duration
+	ObjectStore      ObjectStoreConfig
+}
+
+// ObjectStoreConfig captures configuration for the S3/MinIO compatible storage
+// that persists downloaded video assets.
+type ObjectStoreConfig struct {
+	Endpoint      string
+	Bucket        string
+	Region        string
+	PublicBaseURL string
 }
 
 // Load reads configuration from environment variables, applying sensible defaults
@@ -28,6 +38,12 @@ func Load() (Config, error) {
 		YTDLPPath:        getString("VIDFRIENDS_YTDLP_PATH", "yt-dlp"),
 		YTDLPTimeout:     getDuration("VIDFRIENDS_YTDLP_TIMEOUT", 30*time.Second),
 		MetadataCacheTTL: getDuration("VIDFRIENDS_METADATA_CACHE_TTL", 15*time.Minute),
+		ObjectStore: ObjectStoreConfig{
+			Endpoint:      getString("VIDFRIENDS_S3_ENDPOINT", "http://localhost:9000"),
+			Bucket:        getString("VIDFRIENDS_S3_BUCKET", "vidfriends"),
+			Region:        getString("VIDFRIENDS_S3_REGION", "us-east-1"),
+			PublicBaseURL: getString("VIDFRIENDS_S3_PUBLIC_BASE_URL", "http://localhost:9000/vidfriends"),
+		},
 	}
 
 	return cfg, nil


### PR DESCRIPTION
## Summary
- extend the backend configuration struct to include S3-compatible object storage settings
- default object store values to the documented local MinIO configuration so they can be overridden via environment variables
- mark the TODO entry for wiring object storage configuration as complete

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d5278a1694832f8245ff607db4460a