### PR TITLE
Add frontend testing coverage for widgets and reducer

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,7 +47,7 @@ state to the feature set described in the documentation.
       `/api/v1/auth/refresh` endpoint before the access token expires.
 - [x] Implement a share-video form that calls the backend and handles metadata
       lookup latency states.
-- [ ] Add Vitest/RTL coverage for the dashboard widgets, auth forms, and state
+- [x] Add Vitest/RTL coverage for the dashboard widgets, auth forms, and state
       reducer logic.
 
 ## Documentation

--- a/frontend/src/pages/__tests__/AuthForms.test.tsx
+++ b/frontend/src/pages/__tests__/AuthForms.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import type { Mock } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AppStateContextValue } from '../../state/AppStateProvider';
+import { ForgotPasswordPage } from '../ForgotPasswordPage';
+import { LoginPage } from '../LoginPage';
+import { SignupPage } from '../SignupPage';
+import { useAppState } from '../../state/useAppState';
+
+vi.mock('../../state/useAppState', () => ({
+  useAppState: vi.fn()
+}));
+
+const useAppStateMock = useAppState as unknown as Mock;
+
+function createState(overrides: Partial<AppStateContextValue> = {}): AppStateContextValue {
+  return {
+    auth: { user: null, status: 'anonymous', tokens: null },
+    friends: { pending: [], connections: [] },
+    feed: { entries: [] },
+    signIn: vi.fn(),
+    signUp: vi.fn(),
+    requestPasswordReset: vi.fn(),
+    signOut: vi.fn(),
+    acceptInvite: vi.fn(),
+    declineInvite: vi.fn(),
+    respondToInvite: vi.fn(),
+    shareVideo: vi.fn(),
+    reactToVideo: vi.fn(),
+    ...overrides
+  };
+}
+
+describe('Authentication form components', () => {
+  beforeEach(() => {
+    useAppStateMock.mockReset();
+  });
+
+  it('invokes the sign-in flow and shows errors on failure', async () => {
+    const signIn = vi
+      .fn<AppStateContextValue['signIn']>()
+      .mockRejectedValue(new Error('Invalid credentials.'));
+
+    useAppStateMock.mockReturnValue(createState({ signIn }));
+
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByLabelText(/email/i), 'alex@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'bad-pass');
+    await user.click(screen.getByRole('button', { name: /log in/i }));
+
+    await waitFor(() => expect(signIn).toHaveBeenCalledWith({ email: 'alex@example.com', password: 'bad-pass' }));
+    await screen.findByText(/invalid credentials/i);
+    expect(screen.getByRole('button', { name: /log in/i })).toBeEnabled();
+  });
+
+  it('submits the sign-up form with the provided details', async () => {
+    const signUp = vi.fn<AppStateContextValue['signUp']>().mockResolvedValue({
+      id: 'alex@example.com',
+      email: 'alex@example.com',
+      displayName: 'Alex'
+    });
+
+    useAppStateMock.mockReturnValue(createState({ signUp }));
+
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <SignupPage />
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByLabelText(/display name/i), 'Alex');
+    await user.type(screen.getByLabelText(/^email$/i), 'alex@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'pa55word');
+
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() =>
+      expect(signUp).toHaveBeenCalledWith({
+        displayName: 'Alex',
+        email: 'alex@example.com',
+        password: 'pa55word'
+      })
+    );
+
+    expect(screen.getByRole('button', { name: /create account/i })).toBeEnabled();
+  });
+
+  it('requests a password reset using the entered email', async () => {
+    const requestPasswordReset = vi
+      .fn<AppStateContextValue['requestPasswordReset']>()
+      .mockResolvedValue();
+
+    useAppStateMock.mockReturnValue(createState({ requestPasswordReset }));
+
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <ForgotPasswordPage />
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByLabelText(/email address/i), 'friend@example.com');
+    await user.click(screen.getByRole('button', { name: /send reset link/i }));
+
+    await waitFor(() => expect(requestPasswordReset).toHaveBeenCalledWith('friend@example.com'));
+    await screen.findByText(/you'll receive a reset link shortly/i);
+  });
+});

--- a/frontend/src/pages/__tests__/ShareVideoForm.test.tsx
+++ b/frontend/src/pages/__tests__/ShareVideoForm.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Mock } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AppStateContextValue, FeedEntry } from '../../state/AppStateProvider';
+import { ShareVideoForm } from '../components/ShareVideoForm';
+import { useAppState } from '../../state/useAppState';
+
+vi.mock('../../state/useAppState', () => ({
+  useAppState: vi.fn()
+}));
+
+const useAppStateMock = useAppState as unknown as Mock;
+
+function createState(overrides: Partial<AppStateContextValue> = {}): AppStateContextValue {
+  return {
+    auth: { user: null, status: 'anonymous', tokens: null },
+    friends: { pending: [], connections: [] },
+    feed: { entries: [] },
+    signIn: vi.fn(),
+    signUp: vi.fn(),
+    requestPasswordReset: vi.fn(),
+    signOut: vi.fn(),
+    acceptInvite: vi.fn(),
+    declineInvite: vi.fn(),
+    respondToInvite: vi.fn(),
+    shareVideo: vi.fn(),
+    reactToVideo: vi.fn(),
+    ...overrides
+  };
+}
+
+describe('ShareVideoForm', () => {
+  beforeEach(() => {
+    useAppStateMock.mockReset();
+  });
+
+  it('prompts the user to sign in before sharing videos', () => {
+    useAppStateMock.mockReturnValue(createState());
+
+    render(<ShareVideoForm />);
+
+    expect(screen.getByRole('button', { name: /share video/i })).toBeDisabled();
+    expect(
+      screen.getByText(/sign in to start sharing videos with your friends/i)
+    ).toBeInTheDocument();
+  });
+
+  it('submits shares, shows progress, and resets the form on success', async () => {
+    const shareVideo = vi.fn<Parameters<AppStateContextValue['shareVideo']>, Promise<FeedEntry>>();
+    const mockEntry: FeedEntry = {
+      id: 'entry-1',
+      title: 'Incredible speedruns',
+      sharedBy: 'Alex',
+      sharedAt: new Date().toISOString(),
+      platform: 'YouTube',
+      url: 'https://example.com/watch?v=abc',
+      thumbnailUrl: 'https://example.com/thumb.jpg',
+      channelName: 'Speed Central',
+      durationSeconds: 512,
+      viewCount: 100_000,
+      description: 'The best runs of the week.',
+      tags: ['games'],
+      reactions: { like: 0, love: 0, wow: 0, laugh: 0 },
+      userReaction: null
+    };
+
+    let resolveShare!: (entry: FeedEntry) => void;
+    shareVideo.mockReturnValue(
+      new Promise<FeedEntry>((resolve) => {
+        resolveShare = resolve;
+      })
+    );
+
+    useAppStateMock.mockReturnValue(
+      createState({
+        auth: {
+          user: { id: 'user-1', email: 'user@example.com', displayName: 'User One' },
+          status: 'authenticated',
+          tokens: null
+        },
+        shareVideo
+      })
+    );
+
+    const user = userEvent.setup();
+    render(<ShareVideoForm />);
+
+    const urlInput = screen.getByLabelText(/video url/i);
+    await user.type(urlInput, 'https://example.com/watch?v=abc');
+    await user.type(screen.getByLabelText(/optional title override/i), 'My run');
+
+    const submitButton = screen.getByRole('button', { name: /share video/i });
+    expect(submitButton).toBeEnabled();
+
+    await user.click(submitButton);
+
+    const pendingButton = await screen.findByRole('button', { name: /sharing/i });
+    expect(pendingButton).toBeDisabled();
+    expect(await screen.findByText(/fetching video details/i)).toBeInTheDocument();
+
+    resolveShare(mockEntry);
+
+    await waitFor(() =>
+      expect(shareVideo).toHaveBeenCalledWith({ title: 'My run', url: 'https://example.com/watch?v=abc' })
+    );
+    await screen.findByText(/shared “incredible speedruns” with your friends/i);
+
+    expect(urlInput).toHaveValue('');
+    expect(screen.getByLabelText(/optional title override/i)).toHaveValue('');
+    expect(screen.getByRole('button', { name: /share video/i })).toBeDisabled();
+  });
+
+  it('surfaces backend errors and keeps the form state intact', async () => {
+    const shareVideo = vi
+      .fn<Parameters<AppStateContextValue['shareVideo']>, Promise<FeedEntry>>()
+      .mockRejectedValue(new Error('Unable to reach the server.'));
+
+    useAppStateMock.mockReturnValue(
+      createState({
+        auth: {
+          user: { id: 'user-1', email: 'user@example.com', displayName: 'User One' },
+          status: 'authenticated',
+          tokens: null
+        },
+        shareVideo
+      })
+    );
+
+    const user = userEvent.setup();
+    render(<ShareVideoForm />);
+
+    const urlInput = screen.getByLabelText(/video url/i);
+    await user.type(urlInput, 'https://example.com/watch?v=abc');
+
+    await user.click(screen.getByRole('button', { name: /share video/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/unable to reach the server/i)).toBeInTheDocument()
+    );
+
+    expect(shareVideo).toHaveBeenCalled();
+    expect(urlInput).toHaveValue('https://example.com/watch?v=abc');
+    expect(screen.getByRole('button', { name: /share video/i })).toBeEnabled();
+  });
+});

--- a/frontend/src/pages/__tests__/VideoFeedPanel.test.tsx
+++ b/frontend/src/pages/__tests__/VideoFeedPanel.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Mock } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AppStateContextValue, FeedEntry } from '../../state/AppStateProvider';
+import { VideoFeedPanel } from '../components/VideoFeedPanel';
+import { useAppState } from '../../state/useAppState';
+
+vi.mock('../../state/useAppState', () => ({
+  useAppState: vi.fn()
+}));
+
+const useAppStateMock = useAppState as unknown as Mock;
+
+function createState(overrides: Partial<AppStateContextValue> = {}): AppStateContextValue {
+  return {
+    auth: { user: null, status: 'anonymous', tokens: null },
+    friends: { pending: [], connections: [] },
+    feed: { entries: [] },
+    signIn: vi.fn(),
+    signUp: vi.fn(),
+    requestPasswordReset: vi.fn(),
+    signOut: vi.fn(),
+    acceptInvite: vi.fn(),
+    declineInvite: vi.fn(),
+    respondToInvite: vi.fn(),
+    shareVideo: vi.fn(),
+    reactToVideo: vi.fn(),
+    ...overrides
+  };
+}
+
+const baseEntries: FeedEntry[] = [
+  {
+    id: 'feed-1',
+    title: 'Top 10 Cozy Indie Games',
+    sharedBy: 'Rowan Carter',
+    sharedAt: new Date(Date.now() - 1000 * 60 * 5).toISOString(),
+    platform: 'YouTube',
+    url: 'https://example.com/indie',
+    thumbnailUrl: 'https://example.com/thumb1.jpg',
+    channelName: 'Indie Realm',
+    durationSeconds: 900,
+    viewCount: 42_000,
+    description: 'Discover new cozy titles perfect for winding down after a long day.',
+    tags: ['Games', 'Cozy'],
+    reactions: { like: 18, love: 6, wow: 2, laugh: 1 },
+    userReaction: null
+  },
+  {
+    id: 'feed-2',
+    title: 'How the JWST Sees the Universe',
+    sharedBy: 'Miguel Chen',
+    sharedAt: new Date(Date.now() - 1000 * 60 * 60 * 12).toISOString(),
+    platform: 'Nebula',
+    url: 'https://example.com/jwst',
+    thumbnailUrl: 'https://example.com/thumb2.jpg',
+    channelName: 'Cosmic Perspectives',
+    durationSeconds: 1245,
+    viewCount: 38_700,
+    description: 'Astrophysicist Dr. Mei Park breaks down the science behind the telescope.',
+    tags: ['Science', 'Space'],
+    reactions: { like: 21, love: 11, wow: 7, laugh: 0 },
+    userReaction: 'love'
+  }
+];
+
+describe('VideoFeedPanel', () => {
+  beforeEach(() => {
+    useAppStateMock.mockReset();
+  });
+
+  it('filters entries using the provided controls', async () => {
+    const user = userEvent.setup();
+    useAppStateMock.mockReturnValue(
+      createState({
+        friends: {
+          pending: [],
+          connections: [
+            { id: 'friend-1', displayName: 'Rowan Carter', status: 'online' },
+            { id: 'friend-2', displayName: 'Miguel Chen', status: 'offline' }
+          ]
+        }
+      })
+    );
+
+    render(<VideoFeedPanel feed={{ entries: baseEntries }} />);
+
+    expect(screen.getByText(/top 10 cozy indie games/i)).toBeInTheDocument();
+    expect(screen.getByText(/how the jwst sees the universe/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /from online friends/i }));
+
+    expect(screen.getByText(/top 10 cozy indie games/i)).toBeInTheDocument();
+    expect(screen.queryByText(/how the jwst sees the universe/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /science/i }));
+
+    expect(screen.getByText(/how the jwst sees the universe/i)).toBeInTheDocument();
+    expect(screen.queryByText(/top 10 cozy indie games/i)).not.toBeInTheDocument();
+  });
+
+  it('notifies the parent when a reaction is clicked', async () => {
+    const user = userEvent.setup();
+    const reactToVideo = vi.fn();
+    useAppStateMock.mockReturnValue(
+      createState({
+        friends: { pending: [], connections: [] },
+        reactToVideo
+      })
+    );
+
+    render(<VideoFeedPanel feed={{ entries: baseEntries }} />);
+
+    const [reactionButton] = screen.getAllByTitle('Like reaction');
+
+    await user.click(reactionButton);
+    expect(reactToVideo).toHaveBeenCalledWith('feed-1', 'like');
+
+    await user.click(reactionButton);
+    expect(reactToVideo).toHaveBeenLastCalledWith('feed-1', 'like');
+  });
+
+  it('shows an empty state when there are no entries to display', () => {
+    useAppStateMock.mockReturnValue(createState());
+
+    render(<VideoFeedPanel feed={{ entries: [] }} />);
+
+    expect(
+      screen.getByText(/nothing here yet. share a link or try a different filter/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/state/AppStateProvider.tsx
+++ b/frontend/src/state/AppStateProvider.tsx
@@ -247,7 +247,7 @@ interface AppState {
   };
 }
 
-type AppStateAction =
+export type AppStateAction =
   | { type: 'sign-in'; payload: { user: AuthUser; tokens: SessionTokens } }
   | { type: 'sign-out' }
   | { type: 'refresh-tokens'; payload: { tokens: SessionTokens } }
@@ -364,7 +364,7 @@ function initializeState(defaultState: AppState): AppState {
   };
 }
 
-function appReducer(state: AppState, action: AppStateAction): AppState {
+export function appReducer(state: AppState, action: AppStateAction): AppState {
   switch (action.type) {
     case 'sign-in':
       return {

--- a/frontend/src/state/__tests__/appReducer.test.ts
+++ b/frontend/src/state/__tests__/appReducer.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AppStateAction, FeedEntry, FriendConnection, FriendInvite } from '../AppStateProvider';
+import { appReducer } from '../AppStateProvider';
+
+type AppState = Parameters<typeof appReducer>[0];
+
+function createState(overrides: Partial<AppState> = {}): AppState {
+  return {
+    auth: { user: null, status: 'anonymous', tokens: null },
+    friends: { pending: [], connections: [] },
+    feed: { entries: [] },
+    ...overrides
+  };
+}
+
+describe('appReducer', () => {
+  it('promotes accepted invites into the friend list and removes declined ones', () => {
+    const invite: FriendInvite = { id: 'inv-1', displayName: 'Casey', mutualFriends: 3 };
+    const existingFriend: FriendConnection = {
+      id: 'friend-1',
+      displayName: 'Rowan',
+      status: 'online'
+    };
+
+    const state = createState({
+      friends: {
+        pending: [invite],
+        connections: [existingFriend]
+      }
+    });
+
+    const accepted = appReducer(state, {
+      type: 'resolve-invite',
+      payload: { inviteId: 'inv-1', accepted: true }
+    } satisfies AppStateAction);
+
+    expect(accepted.friends.pending).toHaveLength(0);
+    expect(accepted.friends.connections[0]).toMatchObject({
+      id: invite.id,
+      displayName: invite.displayName,
+      status: 'offline'
+    });
+
+    const declined = appReducer(state, {
+      type: 'resolve-invite',
+      payload: { inviteId: 'inv-1', accepted: false }
+    } satisfies AppStateAction);
+
+    expect(declined.friends.pending).toHaveLength(0);
+    expect(declined.friends.connections).toHaveLength(1);
+    expect(declined.friends.connections[0]).toEqual(existingFriend);
+  });
+
+  it('adds newly shared videos to the beginning of the feed', () => {
+    const originalEntry: FeedEntry = {
+      id: 'feed-1',
+      title: 'Cozy builds',
+      sharedBy: 'Alex',
+      sharedAt: new Date(Date.now() - 60_000).toISOString(),
+      platform: 'YouTube',
+      url: 'https://example.com/1',
+      thumbnailUrl: 'https://example.com/thumb1.jpg',
+      channelName: 'Builders Guild',
+      durationSeconds: 480,
+      viewCount: 12_300,
+      description: 'A calming timelapse build.',
+      tags: ['Relax'],
+      reactions: { like: 2, love: 0, wow: 0, laugh: 0 },
+      userReaction: null
+    };
+    const newEntry: FeedEntry = {
+      ...originalEntry,
+      id: 'feed-2',
+      title: 'Speedrun tips',
+      sharedAt: new Date().toISOString()
+    };
+
+    const state = createState({ feed: { entries: [originalEntry] } });
+
+    const next = appReducer(state, {
+      type: 'share-video',
+      payload: newEntry
+    } satisfies AppStateAction);
+
+    expect(next.feed.entries.map((entry) => entry.id)).toEqual(['feed-2', 'feed-1']);
+  });
+
+  it('toggles reactions and keeps counts consistent', () => {
+    const entry: FeedEntry = {
+      id: 'feed-1',
+      title: 'Morning yoga',
+      sharedBy: 'Jamie',
+      sharedAt: new Date().toISOString(),
+      platform: 'YouTube',
+      url: 'https://example.com/yoga',
+      thumbnailUrl: 'https://example.com/thumb-yoga.jpg',
+      channelName: 'Peaceful Moves',
+      durationSeconds: 1_800,
+      viewCount: 91_500,
+      description: 'Start your day with a gentle routine.',
+      tags: ['Wellness'],
+      reactions: { like: 10, love: 5, wow: 1, laugh: 0 },
+      userReaction: 'love'
+    };
+
+    const state = createState({ feed: { entries: [entry] } });
+
+    const toggledOff = appReducer(state, {
+      type: 'react-to-video',
+      payload: { entryId: 'feed-1', reaction: 'love' }
+    } satisfies AppStateAction);
+
+    expect(toggledOff.feed.entries[0].reactions.love).toBe(4);
+    expect(toggledOff.feed.entries[0].userReaction).toBeNull();
+
+    const switched = appReducer(toggledOff, {
+      type: 'react-to-video',
+      payload: { entryId: 'feed-1', reaction: 'wow' }
+    } satisfies AppStateAction);
+
+    expect(switched.feed.entries[0].reactions).toMatchObject({
+      like: 10,
+      love: 4,
+      wow: 2,
+      laugh: 0
+    });
+    expect(switched.feed.entries[0].userReaction).toBe('wow');
+  });
+});


### PR DESCRIPTION
## Summary
- export the frontend reducer types to enable direct unit testing
- add RTL coverage for ShareVideoForm, VideoFeedPanel, and the auth form components
- exercise reducer edge cases for invites, sharing, and reactions while marking the TODO entry complete

## Testing
- pnpm test -- --runInBand --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d5a66a1b88832fa1c678cdfe08ecc6