### PR TITLE
Expose Compose settings as environment variables

### DIFF
--- a/configs/backend.env.example
+++ b/configs/backend.env.example
@@ -12,6 +12,14 @@ SESSION_SECRET=replace-with-secure-random-string
 # Directory containing SQL migrations.
 VIDFRIENDS_MIGRATIONS=migrations
 
+# Structured logging level emitted by the service (debug, info, warn, error).
+VIDFRIENDS_LOG_LEVEL=info
+
+# Location of the yt-dlp binary and operational timeouts.
+VIDFRIENDS_YTDLP_PATH=yt-dlp
+VIDFRIENDS_YTDLP_TIMEOUT=30s
+VIDFRIENDS_METADATA_CACHE_TTL=15m
+
 # S3-compatible storage configuration used for hosting processed videos.
 VIDFRIENDS_S3_ENDPOINT=http://localhost:9000
 VIDFRIENDS_S3_BUCKET=vidfriends

--- a/configs/deploy.env.example
+++ b/configs/deploy.env.example
@@ -1,22 +1,36 @@
 # Shared environment configuration for Docker Compose deployments.
 
+# Container images used by the stack.
+POSTGRES_IMAGE=postgres:15
+BACKEND_IMAGE=golang:1.22
+FRONTEND_IMAGE=node:20
+MINIO_IMAGE=minio/minio:RELEASE.2024-01-13T07-53-03Z
+MINIO_MC_IMAGE=minio/mc:RELEASE.2024-01-11T07-46-16Z
+YTDLP_IMAGE=ghcr.io/yt-dlp/yt-dlp:2023.11.14
+
 # Database credentials used by PostgreSQL and the backend service.
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=vidfriends
 
-# Connection string the backend uses to reach PostgreSQL inside Compose.
+# Connection string and port the backend uses to reach PostgreSQL inside Compose.
 DATABASE_URL=postgres://postgres:postgres@db:5432/vidfriends?sslmode=disable
+POSTGRES_PORT=5432
 
 # Secret for signing backend session cookies. Replace before running in production.
 SESSION_SECRET=replace-with-secure-random-string
 
-# Optional path to the yt-dlp binary inside the backend container.
+# Backend runtime configuration.
+BACKEND_PORT=8080
+VIDFRIENDS_LOG_LEVEL=info
+VIDFRIENDS_MIGRATIONS=migrations
+VIDFRIENDS_YTDLP_TIMEOUT=30s
+VIDFRIENDS_METADATA_CACHE_TTL=15m
 YT_DLP_PATH=/usr/local/bin/yt-dlp
 
-# Hostnames/ports exposed by the services.
-BACKEND_PORT=8080
+# Frontend configuration.
 FRONTEND_PORT=5173
+FRONTEND_API_BASE_URL=http://backend:8080
 
 # MinIO (S3-compatible) configuration for video storage.
 MINIO_ROOT_USER=vidfriends
@@ -25,6 +39,7 @@ MINIO_API_PORT=9000
 MINIO_CONSOLE_PORT=9001
 
 # S3 bucket settings consumed by the backend.
+VIDFRIENDS_S3_ENDPOINT=http://minio:9000
 VIDFRIENDS_S3_BUCKET=vidfriends
 VIDFRIENDS_S3_REGION=us-east-1
 VIDFRIENDS_S3_PUBLIC_BASE_URL=http://localhost:9000/vidfriends

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -100,6 +100,66 @@ and exposed ports.
   directly from the MinIO endpoint.
 - **Restart policy**: Runs to completion and exits.
 
+## Configuration reference
+
+The Compose stack is configured entirely through environment variables sourced
+from `deploy/.env` and the service-specific `.env` files. The canonical list of
+supported settings and their defaults lives in [`deploy/settings.json`](settings.json).
+The tables below summarise the values you can override when launching the stack.
+
+### Container images
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `POSTGRES_IMAGE` | `postgres:15` | Image used for the PostgreSQL database service. |
+| `BACKEND_IMAGE` | `golang:1.22` | Base image that runs the Go backend in Compose. |
+| `FRONTEND_IMAGE` | `node:20` | Image that powers the Vite development server. |
+| `MINIO_IMAGE` | `minio/minio:RELEASE.2024-01-13T07-53-03Z` | MinIO object storage container image. |
+| `MINIO_MC_IMAGE` | `minio/mc:RELEASE.2024-01-11T07-46-16Z` | MinIO client image that provisions buckets. |
+| `YTDLP_IMAGE` | `ghcr.io/yt-dlp/yt-dlp:2023.11.14` | Helper image used to publish the `yt-dlp` binary onto a shared volume. |
+
+### Database connectivity
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `POSTGRES_USER` | `postgres` | Database superuser created by the `db` service. |
+| `POSTGRES_PASSWORD` | `postgres` | Password associated with `POSTGRES_USER`. |
+| `POSTGRES_DB` | `vidfriends` | Database created on first launch. |
+| `POSTGRES_PORT` | `5432` | Host port that publishes PostgreSQL outside of Docker. |
+| `DATABASE_URL` | `postgres://postgres:postgres@db:5432/vidfriends?sslmode=disable` | Connection string the backend uses to reach PostgreSQL inside the Compose network. |
+
+### Backend runtime
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BACKEND_PORT` | `8080` | Host port published for the Go API. |
+| `SESSION_SECRET` | `replace-with-secure-random-string` | Secret used to sign and verify session cookies. |
+| `VIDFRIENDS_LOG_LEVEL` | `info` | Structured logging level emitted by the service. |
+| `VIDFRIENDS_MIGRATIONS` | `migrations` | Directory containing SQL migration files inside the container. |
+| `YT_DLP_PATH` | `/usr/local/bin/yt-dlp` | Filesystem path to the `yt-dlp` binary mounted in the backend container. |
+| `VIDFRIENDS_YTDLP_TIMEOUT` | `30s` | Maximum time the backend waits for `yt-dlp` metadata responses. |
+| `VIDFRIENDS_METADATA_CACHE_TTL` | `15m` | Lifetime of cached video metadata entries. |
+| `VIDFRIENDS_S3_ENDPOINT` | `http://minio:9000` | Internal endpoint used to talk to MinIO. |
+| `VIDFRIENDS_S3_BUCKET` | `vidfriends` | Bucket name created for storing processed assets. |
+| `VIDFRIENDS_S3_REGION` | `us-east-1` | Region identifier reported to S3 clients. |
+| `VIDFRIENDS_S3_PUBLIC_BASE_URL` | `http://localhost:9000/vidfriends` | Base URL used to build public links to stored videos. |
+
+### Frontend runtime
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `FRONTEND_PORT` | `5173` | Host port used by the Vite dev server. |
+| `FRONTEND_API_BASE_URL` | `http://backend:8080` | API origin the frontend proxies requests to while running in Compose. |
+
+### Object storage credentials
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `MINIO_ROOT_USER` | `vidfriends` | Administrative access key for MinIO. |
+| `MINIO_ROOT_PASSWORD` | `vidfriends-secret` | Administrative secret key for MinIO. |
+| `MINIO_API_PORT` | `9000` | Host port exposing the MinIO S3-compatible API. |
+| `MINIO_CONSOLE_PORT` | `9001` | Host port exposing the MinIO management console. |
+
 ## Usage
 
 ```bash

--- a/deploy/docker-compose.onboarding.yml
+++ b/deploy/docker-compose.onboarding.yml
@@ -19,7 +19,7 @@ services:
       - seed-data:/export/seeds
 
   db-seed:
-    image: postgres:15
+    image: ${POSTGRES_IMAGE:-postgres:15}
     depends_on:
       db:
         condition: service_healthy

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   db:
-    image: postgres:15
+    image: ${POSTGRES_IMAGE:-postgres:15}
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
@@ -19,7 +19,7 @@ services:
       retries: 5
 
   minio:
-    image: minio/minio:RELEASE.2024-01-13T07-53-03Z
+    image: ${MINIO_IMAGE:-minio/minio:RELEASE.2024-01-13T07-53-03Z}
     restart: unless-stopped
     command: server /data --console-address ":9001"
     environment:
@@ -32,7 +32,7 @@ services:
       - "${MINIO_CONSOLE_PORT:-9001}:9001"
 
   createbuckets:
-    image: minio/mc:RELEASE.2024-01-11T07-46-16Z
+    image: ${MINIO_MC_IMAGE:-minio/mc:RELEASE.2024-01-11T07-46-16Z}
     depends_on:
       minio:
         condition: service_started
@@ -51,7 +51,7 @@ services:
       VIDFRIENDS_S3_BUCKET: ${VIDFRIENDS_S3_BUCKET}
 
   yt-dlp:
-    image: ghcr.io/yt-dlp/yt-dlp:2023.11.14
+    image: ${YTDLP_IMAGE:-ghcr.io/yt-dlp/yt-dlp:2023.11.14}
     entrypoint: >-
       /bin/sh -c "
       cp /usr/local/bin/yt-dlp /shared/yt-dlp && chmod +x /shared/yt-dlp &&
@@ -61,7 +61,7 @@ services:
       - yt-dlp-bin:/shared
 
   backend:
-    image: golang:1.22
+    image: ${BACKEND_IMAGE:-golang:1.22}
     depends_on:
       db:
         condition: service_healthy
@@ -75,8 +75,12 @@ services:
       VIDFRIENDS_PORT: ${BACKEND_PORT}
       VIDFRIENDS_DATABASE_URL: ${DATABASE_URL}
       SESSION_SECRET: ${SESSION_SECRET}
-      VIDFRIENDS_YTDLP_PATH: ${YT_DLP_PATH}
-      VIDFRIENDS_S3_ENDPOINT: http://minio:9000
+      VIDFRIENDS_LOG_LEVEL: ${VIDFRIENDS_LOG_LEVEL:-info}
+      VIDFRIENDS_MIGRATIONS: ${VIDFRIENDS_MIGRATIONS:-migrations}
+      VIDFRIENDS_YTDLP_PATH: ${YT_DLP_PATH:-/usr/local/bin/yt-dlp}
+      VIDFRIENDS_YTDLP_TIMEOUT: ${VIDFRIENDS_YTDLP_TIMEOUT:-30s}
+      VIDFRIENDS_METADATA_CACHE_TTL: ${VIDFRIENDS_METADATA_CACHE_TTL:-15m}
+      VIDFRIENDS_S3_ENDPOINT: ${VIDFRIENDS_S3_ENDPOINT:-http://minio:9000}
       VIDFRIENDS_S3_BUCKET: ${VIDFRIENDS_S3_BUCKET}
       VIDFRIENDS_S3_REGION: ${VIDFRIENDS_S3_REGION}
       VIDFRIENDS_S3_PUBLIC_BASE_URL: ${VIDFRIENDS_S3_PUBLIC_BASE_URL}
@@ -90,7 +94,7 @@ services:
       - "${BACKEND_PORT:-8080}:8080"
 
   frontend:
-    image: node:20
+    image: ${FRONTEND_IMAGE:-node:20}
     depends_on:
       backend:
         condition: service_started
@@ -99,7 +103,7 @@ services:
     env_file:
       - ../frontend/.env
     environment:
-      VITE_API_BASE_URL: http://backend:8080
+      VITE_API_BASE_URL: ${FRONTEND_API_BASE_URL:-http://backend:8080}
     volumes:
       - ../frontend:/app
     ports:

--- a/deploy/settings.json
+++ b/deploy/settings.json
@@ -1,0 +1,114 @@
+{
+  "POSTGRES_IMAGE": {
+    "default": "postgres:15",
+    "description": "Container image used for the PostgreSQL database service."
+  },
+  "POSTGRES_USER": {
+    "default": "postgres",
+    "description": "Database user created by the PostgreSQL container."
+  },
+  "POSTGRES_PASSWORD": {
+    "default": "postgres",
+    "description": "Password associated with POSTGRES_USER for local development."
+  },
+  "POSTGRES_DB": {
+    "default": "vidfriends",
+    "description": "Default database created on first boot."
+  },
+  "POSTGRES_PORT": {
+    "default": 5432,
+    "description": "Host port published for PostgreSQL connections."
+  },
+  "DATABASE_URL": {
+    "default": "postgres://postgres:postgres@db:5432/vidfriends?sslmode=disable",
+    "description": "Connection string the backend uses to reach PostgreSQL inside Compose."
+  },
+  "SESSION_SECRET": {
+    "default": "replace-with-secure-random-string",
+    "description": "Secret used by the backend to sign and verify session cookies."
+  },
+  "BACKEND_IMAGE": {
+    "default": "golang:1.22",
+    "description": "Base image used to run the backend service in the Compose workflow."
+  },
+  "BACKEND_PORT": {
+    "default": 8080,
+    "description": "Host port exposed for the backend HTTP API."
+  },
+  "VIDFRIENDS_LOG_LEVEL": {
+    "default": "info",
+    "description": "Structured log level emitted by the backend service."
+  },
+  "VIDFRIENDS_YTDLP_TIMEOUT": {
+    "default": "30s",
+    "description": "Maximum time the backend waits for yt-dlp to return metadata."
+  },
+  "VIDFRIENDS_METADATA_CACHE_TTL": {
+    "default": "15m",
+    "description": "Lifetime for cached video metadata responses."
+  },
+  "VIDFRIENDS_MIGRATIONS": {
+    "default": "migrations",
+    "description": "Directory containing SQL migration files inside the backend container."
+  },
+  "VIDFRIENDS_S3_ENDPOINT": {
+    "default": "http://minio:9000",
+    "description": "Internal endpoint the backend uses to talk to MinIO."
+  },
+  "VIDFRIENDS_S3_BUCKET": {
+    "default": "vidfriends",
+    "description": "Bucket created in MinIO for storing downloaded video assets."
+  },
+  "VIDFRIENDS_S3_REGION": {
+    "default": "us-east-1",
+    "description": "Region identifier presented to S3-compatible clients."
+  },
+  "VIDFRIENDS_S3_PUBLIC_BASE_URL": {
+    "default": "http://localhost:9000/vidfriends",
+    "description": "Base URL used to construct public links to stored assets."
+  },
+  "YT_DLP_PATH": {
+    "default": "/usr/local/bin/yt-dlp",
+    "description": "Filesystem path where the yt-dlp binary is mounted for the backend."
+  },
+  "YTDLP_IMAGE": {
+    "default": "ghcr.io/yt-dlp/yt-dlp:2023.11.14",
+    "description": "Helper image that publishes the yt-dlp binary onto the shared volume."
+  },
+  "FRONTEND_IMAGE": {
+    "default": "node:20",
+    "description": "Image used for the frontend development server container."
+  },
+  "FRONTEND_PORT": {
+    "default": 5173,
+    "description": "Host port exposed for the Vite development server."
+  },
+  "FRONTEND_API_BASE_URL": {
+    "default": "http://backend:8080",
+    "description": "Origin the frontend uses to proxy API requests while running in Compose."
+  },
+  "MINIO_IMAGE": {
+    "default": "minio/minio:RELEASE.2024-01-13T07-53-03Z",
+    "description": "Image that runs the MinIO object storage service."
+  },
+  "MINIO_ROOT_USER": {
+    "default": "vidfriends",
+    "description": "Administrative access key created for MinIO."
+  },
+  "MINIO_ROOT_PASSWORD": {
+    "default": "vidfriends-secret",
+    "description": "Administrative secret key for MinIO."
+  },
+  "MINIO_API_PORT": {
+    "default": 9000,
+    "description": "Host port that exposes the MinIO S3-compatible API."
+  },
+  "MINIO_CONSOLE_PORT": {
+    "default": 9001,
+    "description": "Host port that exposes the MinIO management console."
+  },
+  "MINIO_MC_IMAGE": {
+    "default": "minio/mc:RELEASE.2024-01-11T07-46-16Z",
+    "description": "Image used by the bucket provisioning helper job."
+  }
+}


### PR DESCRIPTION
## Summary
- add `deploy/settings.json` as the canonical list of Compose defaults and expand the sample `.env` files to surface every setting
- update the Docker Compose definitions to read all services and backend runtime knobs from environment variables with sane fallbacks
- document the full environment variable reference in `deploy/README.md` so Docker users know how to override each option

## Testing
- `go test ./...`
- `pnpm --dir frontend test -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68d5abad5ae4832f8f653a13814a0665