### PR TITLE
Replace AppStateProvider mocks with live backend calls

### DIFF
--- a/ROADMAP_TODO.md
+++ b/ROADMAP_TODO.md
@@ -13,7 +13,7 @@ MVP. Items are grouped roughly in the order they should be tackled; update the l
 
 ## Frontend integration
 
-- [ ] Replace the AppStateProvider mock toggles with real API calls once the backend endpoints are stable.
+- [x] Replace the AppStateProvider mock toggles with real API calls once the backend endpoints are stable.
 - [ ] Implement refresh-token handling in the frontend so sessions stay alive without manual reloads.
 - [ ] Build optimistic UI flows (and rollbacks) for friend invitations and video shares.
 - [ ] Add error boundary and toast messaging for API failures surfaced by the new backend responses.

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -27,7 +27,7 @@ setups should override secrets and endpoints accordingly.
 | -------- | ------- | ----------- |
 | `VITE_API_BASE_URL` | `http://localhost:8080` | Base URL for API requests. Update when running the backend on another host or port. |
 | `VITE_USE_MOCKS` | `false` | Enables the mock data layer provided in `configs/frontend.env.example`. Set to `true` while backend endpoints are unfinished. |
-| `VITE_USE_MOCK_DATA` | _unset_ | Some parts of the code check this legacy flag. Set it to `true` alongside `VITE_USE_MOCKS` until the variable names are unified. |
+| `VITE_USE_MOCK_DATA` | _unused_ | Legacy flag removed from the app state provider. Safe to leave unset; use `VITE_USE_MOCKS` for remaining mocks. |
 
 > **Tip:** Vite only exposes variables prefixed with `VITE_`. Restart the dev server after changing `.env.local` values.
 

--- a/docs/STARTUP.md
+++ b/docs/STARTUP.md
@@ -8,8 +8,9 @@ steps below call out known limitations to help you plan your testing strategy.
 2. **Docker Compose** – start the entire stack with containers and minimal host dependencies.
 
 Use whichever method best matches your workflow. The Docker Compose path is usually fastest for first-time contributors, while
-the local toolchain workflow makes iterative backend/frontend development easier. Expect to lean on the frontend mock mode
-(`VITE_USE_MOCKS=true` and `VITE_USE_MOCK_DATA=true`) until more API endpoints are production-ready.
+the local toolchain workflow makes iterative backend/frontend development easier. Keep `VITE_USE_MOCKS=true` if you want
+components that do not yet have APIs to render placeholder content, but note that the global app state now always talks to the
+real backend.
 
 ---
 
@@ -81,9 +82,8 @@ Update the copied files with values that match your environment. At a minimum yo
 - `YT_DLP_PATH` – optional path to the `yt-dlp` binary if it is not on `$PATH`. Metadata lookups fall back to mock data if the
   binary is missing.
 - `VITE_API_BASE_URL` – API origin for the frontend (`http://localhost:8080` in
-  local development). When pointing at a partially implemented backend, set `VITE_USE_MOCKS=true` (and `VITE_USE_MOCK_DATA=true`) to avoid broken requests.
-- `VITE_USE_MOCKS` – toggle the frontend's mock service layer (`false` by default, but `true` is recommended until the API
-  stabilizes). Some components also look for `VITE_USE_MOCK_DATA`; keep both flags in sync for now.
+  local development). The AppStateProvider always uses this endpoint for authentication, friends, and feed data.
+- `VITE_USE_MOCKS` – toggle the remaining mock service layer (`false` by default). Set this to `true` when you need placeholder content for features without finished APIs.
 - `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` – credentials the
   Docker Compose workflow applies to the PostgreSQL container.
 - `BACKEND_PORT` / `FRONTEND_PORT` – override ports exposed by Docker Compose if
@@ -152,18 +152,18 @@ pnpm dev       # or npm run dev
 ```
 
 By default the development server runs on `http://localhost:5173`. It proxies API requests to the Go backend using
-`VITE_API_BASE_URL`. Leave `VITE_USE_MOCKS=true` (and `VITE_USE_MOCK_DATA=true`) if you want dashboards and invites to render without depending on the unfinished
-backend.
+`VITE_API_BASE_URL`. Ensure the backend is running; otherwise authentication, friends, and feed views will surface empty
+states. You can still enable `VITE_USE_MOCKS=true` to stub out components that lack endpoints.
 
 ### 4.5 Verify the stack
 
-1. Visit `http://localhost:5173` and sign up for a new account. (If the backend rejects the request, fall back to the mock user
-   toggle and record the issue.)
-2. Add a friend using their username or email. The UI will currently use mock data when the API returns errors.
+1. Visit `http://localhost:5173` and sign up for a new account. If anything fails, file an issue rather than switching back to
+   the legacy mock data.
+2. Add a friend using their username or email and respond to invitations. The UI now mirrors the backend state instead of local
+   fixtures.
 3. Share a video link to confirm yt-dlp metadata retrieval. Downloads are skipped for now, but metadata lookups should succeed
    when `yt-dlp` is available.
-4. Check the "Feed" tab to ensure shared videos appear. Expect placeholder content until real friendships and shares exist in the
-   database.
+4. Check the "Feed" tab to ensure shared videos appear for your account.
 
 The backend logs should show API traffic, even if some handlers return TODO responses. Track unexpected failures in the roadmap so
 they can be prioritized.

--- a/frontend/src/pages/__tests__/AuthFlows.test.tsx
+++ b/frontend/src/pages/__tests__/AuthFlows.test.tsx
@@ -16,6 +16,16 @@ function createJsonResponse(status: number, body: JsonValue): Response {
   } as Response;
 }
 
+function extractUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.toString();
+  }
+  return input.url;
+}
+
 function renderApp(initialEntries: string[]) {
   return render(
     <AppStateProvider>
@@ -27,7 +37,7 @@ function renderApp(initialEntries: string[]) {
 }
 
 describe('VidFriends authentication journeys', () => {
-  const fetchMock = vi.fn<[], Promise<Response>>();
+  const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>();
 
   beforeEach(() => {
     vi.stubGlobal('fetch', fetchMock);
@@ -41,16 +51,26 @@ describe('VidFriends authentication journeys', () => {
   });
 
   it('signs in a user and routes them to the dashboard', async () => {
-    fetchMock.mockResolvedValueOnce(
-      createJsonResponse(200, {
-        tokens: {
-          accessToken: 'access-token',
-          accessExpiresAt: new Date(Date.now() + 600_000).toISOString(),
-          refreshToken: 'refresh-token',
-          refreshExpiresAt: new Date(Date.now() + 86_400_000).toISOString()
-        }
-      })
-    );
+    const tokens = {
+      accessToken: 'access-token',
+      accessExpiresAt: new Date(Date.now() + 600_000).toISOString(),
+      refreshToken: 'refresh-token',
+      refreshExpiresAt: new Date(Date.now() + 86_400_000).toISOString()
+    };
+
+    fetchMock.mockImplementation((input, init) => {
+      const url = extractUrl(input);
+      if (url.includes('/api/v1/auth/login')) {
+        return Promise.resolve(createJsonResponse(200, { tokens }));
+      }
+      if (url.includes('/api/v1/friends')) {
+        return Promise.resolve(createJsonResponse(200, { requests: [] }));
+      }
+      if (url.includes('/api/v1/videos/feed')) {
+        return Promise.resolve(createJsonResponse(200, { entries: [] }));
+      }
+      return Promise.reject(new Error(`Unhandled request: ${url}`));
+    });
 
     const user = userEvent.setup();
     renderApp(['/login']);
@@ -59,13 +79,28 @@ describe('VidFriends authentication journeys', () => {
     await user.type(screen.getByLabelText(/password/i), 'sup3r-secure');
     await user.click(screen.getByRole('button', { name: /log in/i }));
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+
     const [requestUrl, requestInit] = fetchMock.mock.calls[0];
     expect(requestUrl).toContain('/api/v1/auth/login');
     expect(requestInit?.method).toBe('POST');
     expect(requestInit?.body).toEqual(
       JSON.stringify({ email: 'alex@example.com', password: 'sup3r-secure' })
     );
+
+    const friendsCall = fetchMock.mock.calls.find(([callInput]) =>
+      extractUrl(callInput).includes('/api/v1/friends')
+    );
+    expect(friendsCall?.[1]?.headers).toMatchObject({
+      Authorization: `Bearer ${tokens.accessToken}`
+    });
+
+    const feedCall = fetchMock.mock.calls.find(([callInput]) =>
+      extractUrl(callInput).includes('/api/v1/videos/feed')
+    );
+    expect(feedCall?.[1]?.headers).toMatchObject({
+      Authorization: `Bearer ${tokens.accessToken}`
+    });
 
     await screen.findByRole('heading', { name: /welcome back, alex!/i });
 
@@ -99,16 +134,26 @@ describe('VidFriends authentication journeys', () => {
   });
 
   it('creates a new account and shows the personalized dashboard welcome', async () => {
-    fetchMock.mockResolvedValueOnce(
-      createJsonResponse(200, {
-        tokens: {
-          accessToken: 'new-access-token',
-          accessExpiresAt: new Date(Date.now() + 600_000).toISOString(),
-          refreshToken: 'new-refresh-token',
-          refreshExpiresAt: new Date(Date.now() + 86_400_000).toISOString()
-        }
-      })
-    );
+    const tokens = {
+      accessToken: 'new-access-token',
+      accessExpiresAt: new Date(Date.now() + 600_000).toISOString(),
+      refreshToken: 'new-refresh-token',
+      refreshExpiresAt: new Date(Date.now() + 86_400_000).toISOString()
+    };
+
+    fetchMock.mockImplementation((input, init) => {
+      const url = extractUrl(input);
+      if (url.includes('/api/v1/auth/signup')) {
+        return Promise.resolve(createJsonResponse(200, { tokens }));
+      }
+      if (url.includes('/api/v1/friends')) {
+        return Promise.resolve(createJsonResponse(200, { requests: [] }));
+      }
+      if (url.includes('/api/v1/videos/feed')) {
+        return Promise.resolve(createJsonResponse(200, { entries: [] }));
+      }
+      return Promise.reject(new Error(`Unhandled request: ${url}`));
+    });
 
     const user = userEvent.setup();
     renderApp(['/signup']);


### PR DESCRIPTION
## Summary
- route the AppStateProvider through the real backend for friends, feed, and sharing flows while handling expired sessions
- refresh the startup and environment docs to explain the new expectations and mark the roadmap item complete
- update authentication flow tests to stub the additional API traffic introduced by the live backend calls

## Testing
- pnpm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d6278a63b4832f8312dccc67fd2c1d