### PR TITLE
Add CI type checks and go vet coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,15 @@ jobs:
             echo "No Go module found in backend/. Skipping Go tests."
           fi
 
+      - name: Run Go vet
+        working-directory: backend
+        run: |
+          if [ -f go.mod ]; then
+            go vet ./...
+          else
+            echo "No Go module found in backend/. Skipping go vet."
+          fi
+
   frontend-tests:
     name: Frontend Unit Tests
     runs-on: ubuntu-latest
@@ -88,3 +97,32 @@ jobs:
 
       - name: Run lint checks
         run: bash scripts/lint.sh
+
+  type-checks:
+    name: Type Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: |
+          if [ ! -f package.json ]; then
+            echo "No frontend/package.json found. Skipping type checks."
+            exit 0
+          fi
+          corepack enable pnpm
+          pnpm install --frozen-lockfile
+
+      - name: Run TypeScript type checks
+        if: hashFiles('frontend/package.json') != ''
+        working-directory: frontend
+        run: pnpm run typecheck

--- a/ROADMAP_TODO.md
+++ b/ROADMAP_TODO.md
@@ -22,7 +22,7 @@ MVP. Items are grouped roughly in the order they should be tackled; update the l
 
 - [x] Document end-to-end manual test cases that verify signup, login, friend invites, and sharing flows.
 - [x] Expand automated test coverage: backend integration tests against PostgreSQL, frontend Vitest + React Testing Library suites.
-- [ ] Set up CI workflows that run Go tests, frontend tests, linting, and type checks on every pull request.
+- [x] Set up CI workflows that run Go tests, frontend tests, linting, and type checks on every pull request.
 - [ ] Establish staging Docker images (backend + frontend) published from main to exercise deployment paths.
 
 ## Launch readiness

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "vitest",
-    "lint": "eslint . --ext ts,tsx --max-warnings 0"
+    "lint": "eslint . --ext ts,tsx --max-warnings 0",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary
- add a Go vet step to the CI workflow to surface static analysis issues alongside unit tests
- introduce a dedicated TypeScript type-check job and npm script to keep frontend builds type-safe
- mark the roadmap item for CI coverage as complete now that tests, linting, and type checks run in CI

## Testing
- go test ./...
- go vet ./...
- pnpm run typecheck


------
https://chatgpt.com/codex/tasks/task_e_68d648572778832fa849ed166875037a