### PR TITLE
Add staging tags to container builds

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -59,6 +59,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=tag
             type=sha
+            type=raw,value=staging,enable=${{ github.ref == 'refs/heads/main' }}
           labels: |
             org.opencontainers.image.title=VidFriends ${{ matrix.service }}
             org.opencontainers.image.source=${{ github.repositoryUrl }}

--- a/ROADMAP_TODO.md
+++ b/ROADMAP_TODO.md
@@ -23,7 +23,7 @@ MVP. Items are grouped roughly in the order they should be tackled; update the l
 - [x] Document end-to-end manual test cases that verify signup, login, friend invites, and sharing flows.
 - [x] Expand automated test coverage: backend integration tests against PostgreSQL, frontend Vitest + React Testing Library suites.
 - [x] Set up CI workflows that run Go tests, frontend tests, linting, and type checks on every pull request.
-- [ ] Establish staging Docker images (backend + frontend) published from main to exercise deployment paths.
+- [x] Establish staging Docker images (backend + frontend) published from main to exercise deployment paths.
 
 ## Launch readiness
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -138,7 +138,10 @@ arm64) for the backend and frontend whenever changes land on `main`, a release
 is published, or the workflow is triggered manually. The GitHub Actions workflow
 [`container-build.yml`](../.github/workflows/container-build.yml) uses Docker
 Buildx with QEMU emulation to produce and push manifests to the GitHub Container
-Registry under `ghcr.io/<org>/<repo>-<service>`.
+Registry under `ghcr.io/<org>/<repo>-<service>`. When the workflow runs on the
+`main` branch it additionally stamps the images with a persistent `staging` tag
+so deployment pipelines can always pull the latest mainline build without
+guessing the commit SHA.
 
 If you need to test builds locally with the same configuration, install
 Docker Buildx and run:
@@ -152,6 +155,16 @@ docker buildx build \
 ```
 
 Replace the Dockerfile path and tag for the frontend image as needed.
+
+To exercise the staging deployment path you can pull the latest mainline builds
+directly:
+
+```bash
+docker pull ghcr.io/<org>/<repo>-backend:staging
+docker pull ghcr.io/<org>/<repo>-frontend:staging
+```
+
+Update `<org>`/`<repo>` to match the GitHub namespace that hosts VidFriends.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- tag backend and frontend container images built from main with a persistent staging alias
- document how to pull the staging images and note the new tag in the deployment guide
- mark the staging image roadmap item as complete

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d64adf9434832f823ffcf74f819123